### PR TITLE
Add shared Lambda DLQ and processor

### DIFF
--- a/bot/__tests__/dlq.test.ts
+++ b/bot/__tests__/dlq.test.ts
@@ -92,8 +92,8 @@ describe('dlq handler', () => {
     const editCall = moduleMockApi.edit.mock.calls[0];
     const content = editCall[2] as string;
 
-    expect(content).toContain('\"messageId\": \"msg-2\"');
-    expect(content).toContain('\"body\": \"not-json\"');
+    expect(content).toContain('"messageId": "msg-2"');
+    expect(content).toContain('"body": "not-json"');
   });
 
   it('should handle record without body', async () => {
@@ -112,6 +112,6 @@ describe('dlq handler', () => {
     const editCall = moduleMockApi.edit.mock.calls[0];
     const content = editCall[2] as string;
 
-    expect(content).toContain('\"messageId\": \"msg-3\"');
+    expect(content).toContain('"messageId": "msg-3"');
   });
 });

--- a/bot/__tests__/dlq.test.ts
+++ b/bot/__tests__/dlq.test.ts
@@ -1,0 +1,117 @@
+import {
+  describe, it, expect, jest, beforeEach, afterEach,
+} from '@jest/globals';
+import WikiApiMock from '../../testConfig/mocks/wikiApi.mock';
+
+const moduleMockApi = WikiApiMock();
+
+jest.unstable_mockModule('../wiki/WikiApi', () => ({
+  __esModule: true,
+  default: () => moduleMockApi,
+}));
+
+const { main } = await import('../dlq/index');
+
+describe('dlq handler', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-15T12:00:00Z')); // Monday - not Shabath
+    jest.clearAllMocks();
+    moduleMockApi.articleContent.mockResolvedValue({ content: '', revid: 123 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should write a log entry for DLQ records and parse JSON body', async () => {
+    const event = {
+      Records: [
+        {
+          messageId: 'msg-1',
+          body: '{"foo":"bar"}',
+          attributes: {
+            ApproximateReceiveCount: '1',
+          },
+        },
+      ],
+    };
+
+    await main(event);
+
+    expect(moduleMockApi.edit).toHaveBeenCalledTimes(1);
+
+    const editCall = moduleMockApi.edit.mock.calls[0];
+    const content = editCall[2] as string;
+
+    expect(content).toContain('===שגיאות===');
+    expect(content).toContain('"source": "lambda-dlq"');
+    expect(content).toContain('"messageId": "msg-1"');
+    expect(content).toContain('"foo": "bar"');
+  });
+
+  it('should log info when no records are present', async () => {
+    const event = { Records: [] as unknown[] };
+
+    await main(event);
+
+    expect(moduleMockApi.edit).toHaveBeenCalledTimes(1);
+
+    const editCall = moduleMockApi.edit.mock.calls[0];
+    const content = editCall[2] as string;
+
+    expect(content).toContain('===לוגים===');
+    expect(content).toContain('DLQ event received with no records');
+  });
+
+  it('should handle undefined event', async () => {
+    await main(undefined as unknown as { Records: unknown[] });
+
+    expect(moduleMockApi.edit).toHaveBeenCalledTimes(1);
+
+    const editCall = moduleMockApi.edit.mock.calls[0];
+    const content = editCall[2] as string;
+
+    expect(content).toContain('DLQ event received with no records');
+  });
+
+  it('should log raw body when JSON parsing fails', async () => {
+    const event = {
+      Records: [
+        {
+          messageId: 'msg-2',
+          body: 'not-json',
+        },
+      ],
+    };
+
+    await main(event);
+
+    expect(moduleMockApi.edit).toHaveBeenCalledTimes(1);
+
+    const editCall = moduleMockApi.edit.mock.calls[0];
+    const content = editCall[2] as string;
+
+    expect(content).toContain('\"messageId\": \"msg-2\"');
+    expect(content).toContain('\"body\": \"not-json\"');
+  });
+
+  it('should handle record without body', async () => {
+    const event = {
+      Records: [
+        {
+          messageId: 'msg-3',
+        },
+      ],
+    };
+
+    await main(event);
+
+    expect(moduleMockApi.edit).toHaveBeenCalledTimes(1);
+
+    const editCall = moduleMockApi.edit.mock.calls[0];
+    const content = editCall[2] as string;
+
+    expect(content).toContain('\"messageId\": \"msg-3\"');
+  });
+});

--- a/bot/__tests__/kineretIndex.test.ts
+++ b/bot/__tests__/kineretIndex.test.ts
@@ -16,6 +16,7 @@ const mockDeadSeaModel = {
 };
 
 const wikiApiMock = WikiApiMock();
+const fetchUrlLikeBrowserMock: any = jest.fn();
 
 jest.unstable_mockModule('../wiki/WikiApi', () => ({
   default: jest.fn(() => wikiApiMock),
@@ -33,7 +34,17 @@ jest.unstable_mockModule('../kineret/DeadSeaModel', () => ({
   default: jest.fn(() => mockDeadSeaModel),
 }));
 
-const { default: kineretBot, defaultDataFetcher, getCurrentDate } = await import('../kineret/index');
+jest.unstable_mockModule('../utilities', () => ({
+  fetchUrlLikeBrowser: (url: string) => fetchUrlLikeBrowserMock(url),
+  getLocalTimeAndDate: (dateString: string) => dateString,
+}));
+
+const {
+  default: kineretBot,
+  defaultDataFetcher,
+  getCurrentDate,
+  kineretDataFetcher,
+} = await import('../kineret/index');
 
 describe('kineretBot', () => {
   beforeEach(() => {
@@ -79,7 +90,7 @@ describe('kineretBot', () => {
     it('should throw error on fetch failure', async () => {
       jest.spyOn(global, 'fetch').mockResolvedValue({
         ok: false,
-      } as any);
+      } as Response);
 
       await expect(defaultDataFetcher('https://example.com')).rejects.toThrow('Failed to fetch data from https://example.com');
     });
@@ -90,6 +101,45 @@ describe('kineretBot', () => {
       const result = getCurrentDate();
 
       expect(result).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('kineretDataFetcher', () => {
+    it('should parse level and date from html', async () => {
+      fetchUrlLikeBrowserMock.mockResolvedValue({
+        text: async () => `
+          <div class="hp_miflas_height">-209.55</div>
+          <div class="hp_miflas_date">13/04/2026</div>
+        `,
+      });
+
+      const result = await kineretDataFetcher('https://kineret.org.il/');
+
+      expect(fetchUrlLikeBrowserMock).toHaveBeenCalledWith('https://kineret.org.il/');
+      expect(result).toStrictEqual({
+        result: {
+          records: [
+            {
+              Survey_Date: '13/04/2026',
+              Kinneret_Level: -209.55,
+              _id: 0,
+            },
+          ],
+        },
+      });
+    });
+
+    it('should throw when missing level or date', async () => {
+      fetchUrlLikeBrowserMock.mockResolvedValue({
+        text: async () => `
+          <div class="hp_miflas_height"></div>
+          <div class="hp_miflas_date">no-date</div>
+        `,
+      });
+
+      await expect(kineretDataFetcher('https://kineret.org.il/'))
+        .rejects
+        .toThrow('Failed to parse level or date');
     });
   });
 });

--- a/bot/dlq/index.ts
+++ b/bot/dlq/index.ts
@@ -1,0 +1,43 @@
+import botLoggerDecorator from '../decorators/botLoggerDecorator';
+import { logger } from '../utilities/logger';
+
+type SqsRecord = {
+  messageId?: string;
+  body?: string;
+  attributes?: Record<string, string>;
+  messageAttributes?: Record<string, unknown>;
+};
+
+type SqsEvent = {
+  Records?: SqsRecord[];
+};
+
+export default async function handleDlq(event: SqsEvent): Promise<void> {
+  const records = event?.Records ?? [];
+  if (!records.length) {
+    logger.logInfo('DLQ event received with no records');
+    return;
+  }
+
+  records.forEach((record, index) => {
+    let parsedBody: unknown = record.body;
+    if (record.body) {
+      try {
+        parsedBody = JSON.parse(record.body);
+      } catch {
+        parsedBody = record.body;
+      }
+    }
+
+    logger.logError({
+      source: 'lambda-dlq',
+      index,
+      messageId: record.messageId,
+      body: parsedBody,
+      attributes: record.attributes,
+      messageAttributes: record.messageAttributes,
+    });
+  });
+}
+
+export const main = botLoggerDecorator(handleDlq, { botName: 'DLQ' });

--- a/bot/scripts/oneTime/removeTheaterGuide.ts
+++ b/bot/scripts/oneTime/removeTheaterGuide.ts
@@ -1,0 +1,70 @@
+import WikiApi from '../../wiki/WikiApi';
+import WikidataAPI from '../../wiki/WikidataAPI';
+import { findTemplates, getTemplateArrayData } from '../../wiki/newTemplateParser';
+import { asyncGeneratorMapWithSequence } from '../../utilities';
+
+const THEATER_GUIDE_TEMPLATE = 'מדריך לתיאטרון';
+const FILMMAKER_PROFILES_TEMPLATE = 'פרופילי קולנוענים-מוזיקאים';
+const THEATER_GUIDE_PROPERTY = 'P10391';
+
+export default async function removeTheaterGuide() {
+  const api = WikiApi();
+  const wikidataApi = WikidataAPI();
+  await api.login();
+  await wikidataApi.login();
+
+  const generator = api.getArticlesWithTemplate(THEATER_GUIDE_TEMPLATE);
+
+  let count = 0;
+
+  await asyncGeneratorMapWithSequence(1, generator, (page) => async () => {
+    const content = page.revisions?.[0].slots.main['*'];
+    const revid = page.revisions?.[0].revid;
+    const filmmakerTemplates = content ? findTemplates(content, FILMMAKER_PROFILES_TEMPLATE, page.title) : [];
+
+    if (!content || !revid || filmmakerTemplates.length === 0) {
+      console.log({ hasContent: !!content, hasRevid: !!revid, hasTemplate: !!filmmakerTemplates.length }, page.title);
+      return;
+    }
+    try {
+      const qid = await api.getWikiDataItem(page.title);
+      if (!qid) {
+        console.log('No qid', page.title);
+        return;
+      }
+      const entity = await wikidataApi.getClaim(qid, THEATER_GUIDE_PROPERTY);
+      const theatherGuideId = entity?.[0]?.mainsnak.datavalue.value;
+      if (!theatherGuideId) {
+        console.log('No theatherGuideId', page.title);
+        return;
+      }
+      const templates = findTemplates(content, THEATER_GUIDE_TEMPLATE, page.title);
+      let newContent = content;
+      for (const template of templates) {
+        const arrayData = getTemplateArrayData(template, THEATER_GUIDE_TEMPLATE, page.title);
+        if (arrayData[0] === theatherGuideId) {
+          newContent = newContent.replace(`*${template}\n`, '');
+          newContent = newContent.replace(`* ${template}\n`, '');
+          newContent = newContent.replace(`*ֿ\t${template}\n`, '');
+        }
+      }
+
+      if (newContent !== content) {
+        console.log(`[${page.title}] Removing ${THEATER_GUIDE_TEMPLATE}`);
+        await api.edit(
+          page.title,
+          `הסרת {{${THEATER_GUIDE_TEMPLATE}}} (מוכללת ב{{${FILMMAKER_PROFILES_TEMPLATE}}}) ([[מיוחד:הבדל/43074245|בקשה בוק:בב]])`,
+          newContent,
+          revid,
+        );
+        count += 1;
+      } else {
+        console.log('No change', page.title);
+      }
+    } catch (error) {
+      console.error(`[${page.title}] Error:`, error);
+    }
+  });
+
+  console.log(`Finished. Total removed: ${count}`);
+}

--- a/build/t01.cf.yaml
+++ b/build/t01.cf.yaml
@@ -43,6 +43,9 @@ Globals:
       Bucket: !Ref BucketCodeName
       Key: dist.zip
       Version: !Ref DistCodeVersionId
+    DeadLetterQueue:
+      Type: SQS
+      TargetArn: !GetAtt GeneralDlqQueue.Arn
     Environment:
       Variables:
         USER_NAME: !Ref WikiUserName
@@ -237,12 +240,36 @@ Resources:
         ImageUri: !Sub ${AWS::AccountId}.dkr.ecr.us-east-1.amazonaws.com/wiki-bot-playwright:${ImageVersion}
       Timeout: 900
       MemorySize: 2048
+      DeadLetterConfig:
+        TargetArn: !GetAtt GeneralDlqQueue.Arn
       Environment:
         Variables:
           USER_NAME: !Ref WikiUserName
           PASSWORD: !Ref WikiPassword
       EphemeralStorage:
         Size: 2048
+
+  GeneralDlqQueue:
+    Type: AWS::SQS::Queue
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      QueueName: wiki-bot-dlq
+      MessageRetentionPeriod: 1209600
+
+  GeneralDlqProcessorFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: wiki-bot-dlq-logger
+      Handler: dist/dlq/index.main
+      Timeout: 60
+      MemorySize: 512
+      Events:
+        DLQEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt GeneralDlqQueue.Arn
+            BatchSize: 1
 
   IronSwordsEventRule:
     Type: AWS::Events::Rule

--- a/build/t01.cf.yaml
+++ b/build/t01.cf.yaml
@@ -235,9 +235,6 @@ Resources:
       Role: !GetAtt IronSwordsFunctionRole.Arn
       Code:
         ImageUri: !Sub ${AWS::AccountId}.dkr.ecr.us-east-1.amazonaws.com/wiki-bot-playwright:${ImageVersion}
-      ImageConfig:
-        Command:
-          - dist/ironSwords/index.main
       Timeout: 900
       MemorySize: 2048
       Environment:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint:test": "eslint './**/*.ts' --max-warnings 0",
     "type-check": "tsc --noEmit",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "build": "rm -rf dist && tsc --project tsconfig.build.json && node scripts/add-js-extensions.mjs",
     "update-env": "tsx --env-file=.env ./build/update-env.ts",
     "docker-build": "sh ./build/wiki-bot-playwright/build.sh",


### PR DESCRIPTION
## Summary
- Add shared SQS DLQ for Lambda functions via SAM Globals
- Add DLQ processor Lambda that logs failures to the wiki log page
- Wire IronSwords Lambda to the shared DLQ

## Testing
- Not run (not requested)
