### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/bot/__tests__/getArguments.test.ts
+++ b/bot/__tests__/getArguments.test.ts
@@ -4,7 +4,7 @@ import { getArguments } from '../decorators/getArguments';
 describe('getArguments', () => {
   it('should parse args from function', () => {
     // eslint-disable-next-line no-multi-spaces, @typescript-eslint/no-unused-vars, no-unused-vars
-    function a({ wikiApi, asdasd }, b: string,     c: number) {
+    function a({ wikiApi, asdasd }: { wikiApi: unknown, asdasd: unknown }, b: string,     c: number) {
     }
 
     expect(getArguments(a)).toStrictEqual([['wikiApi', 'asdasd'], 'b', 'c']);
@@ -12,7 +12,7 @@ describe('getArguments', () => {
 
   it('should parse args from arrow function', () => {
     // eslint-disable-next-line no-multi-spaces, @typescript-eslint/no-unused-vars, no-unused-vars
-    const a = ({ wikiApi, asdasd }, b: string, c: number) => {
+    const a = ({ wikiApi, asdasd }: { wikiApi: unknown, asdasd: unknown }, b: string, c: number) => {
     };
 
     expect(getArguments(a)).toStrictEqual([['wikiApi', 'asdasd'], 'b', 'c']);
@@ -24,7 +24,7 @@ describe('getArguments', () => {
       // eslint-disable-next-line indent
 // /* comment */
 /* eslint-disable-next-line no-multi-spaces, @typescript-eslint/no-unused-vars, no-unused-vars */ // eslint-disable-line indent
-      { wikiApi,  /* comment //  */  asdasd }, /* comment */
+      { wikiApi,  /* comment //  */  asdasd }: { wikiApi: unknown, asdasd: unknown }, /* comment */
       /*
     eslint-disable-next-line no-multi-spaces, @typescript-eslint/no-unused-vars, no-unused-vars
     */

--- a/bot/__tests__/knessetBillLinksRunner.test.ts
+++ b/bot/__tests__/knessetBillLinksRunner.test.ts
@@ -27,7 +27,7 @@ describe('fixKnessetBillLinks', () => {
       yield* [];
     });
     mockAsyncGeneratorMapWithSequence.mockImplementation(
-      async (_sequenceSize: number, _generator: unknown, callback) => {
+      async (_sequenceSize: number, _generator: unknown, callback: (page: unknown) => () => Promise<unknown>) => {
         await callback({
           pageid: 1, ns: 0, title: 'ערך', extlinks: [],
         })();

--- a/bot/admin/protect.ts
+++ b/bot/admin/protect.ts
@@ -258,3 +258,37 @@ async function writeMainPageProtectionLogs(
   const logs = articleLogsFromTitles(needToProtect, errors);
   await writeAdminBotLogs(api, [...logs, ...needProtectLogs], 'משתמש:Sapper-bot/הגנת דפים שמופיעים בעמוד הראשי');
 }
+
+async function writeCopyrightLogsIfNeeded(api: IWikiApi) {
+  if (!runChecks) {
+    return;
+  }
+  const pagesWithCopyrightIssues = await pagesWithCopyrightIssuesInMainPage();
+  if (pagesWithCopyrightIssues.length) {
+    await writeAdminBotLogs(api, pagesWithCopyrightIssues, 'משתמש:Sapper-bot/זכויות יוצרים');
+  }
+}
+
+export async function protectBot() {
+  const api = WikiApi();
+  await api.login();
+
+  const unitPages = await getUnitPagesToProtect(api);
+  const templateCssPages = await getTemplateCssPagesToProtect(api);
+  const needToProtect = await collectMainPagePagesToProtect(api);
+  const allConvertPages = await getConvertBotPagesToProtect(api);
+  const convertPages = filterConvertBotPages(allConvertPages);
+
+  const errors = await protectPages(api, needToProtect, MAIN_PAGE_PROTECT, 'מופיע בעמוד הראשי');
+  const convertErrors = await protectPages(api, convertPages, MAIN_PAGE_PROTECT, 'דפי מפרט של בוט ההסבה');
+  const unitErrors = await protectPages(api, unitPages, UNIT_NAMESPACE_PROTECT, 'הגנה על מרחב יחידה');
+  const templateCssErrors = await protectPages(api, templateCssPages, UNIT_NAMESPACE_PROTECT, 'הגנה על דפי CSS במרחב תבנית');
+
+  await writeConvertPageLogs(api, allConvertPages, convertPages, convertErrors);
+  await writeUnitPageLogs(api, unitPages, unitErrors);
+  await writeTemplateCssPageLogs(api, templateCssPages, templateCssErrors);
+  await writeMainPageProtectionLogs(api, needToProtect, errors);
+  await writeCopyrightLogsIfNeeded(api);
+}
+
+export const main = botLoggerDecorator(protectBot, { botName: 'בוט הגנת דפים שמופיעים בעמוד הראשי' });

--- a/bot/admin/protect.ts
+++ b/bot/admin/protect.ts
@@ -7,6 +7,7 @@ import pagesWithoutProtectInMainPage from './pagesWithoutProtectInMainPage';
 import pagesWithCopyrightIssuesInMainPage from './pagesWithCopyrightIssuesInMainPage';
 import WikiApi, { IWikiApi } from '../wiki/WikiApi';
 import { logger } from '../utilities/logger';
+import { type PageInfo } from '../types';
 
 function getMonthTemplates(month: number, year: number, startWithDay = 1) {
   const dates: string[] = [];
@@ -39,7 +40,7 @@ const MODULE_NAMESPACE = 828;
 const TEMPLATE_CSS_SEARCH = 'contentmodel:sanitized-css';
 
 async function needProtectFromTitles(api: IWikiApi, titles: string[]): Promise<string[]> {
-  const promises: Array<Promise<import('../types').PageInfo[]>> = [];
+  const promises: Array<Promise<PageInfo[]>> = [];
   for (let i = 0; i < titles.length; i += 50) {
     promises.push(api.info(titles.slice(i, i + 50)));
   }
@@ -257,37 +258,3 @@ async function writeMainPageProtectionLogs(
   const logs = articleLogsFromTitles(needToProtect, errors);
   await writeAdminBotLogs(api, [...logs, ...needProtectLogs], 'משתמש:Sapper-bot/הגנת דפים שמופיעים בעמוד הראשי');
 }
-
-async function writeCopyrightLogsIfNeeded(api: IWikiApi) {
-  if (!runChecks) {
-    return;
-  }
-  const pagesWithCopyrightIssues = await pagesWithCopyrightIssuesInMainPage();
-  if (pagesWithCopyrightIssues.length) {
-    await writeAdminBotLogs(api, pagesWithCopyrightIssues, 'משתמש:Sapper-bot/זכויות יוצרים');
-  }
-}
-
-export async function protectBot() {
-  const api = WikiApi();
-  await api.login();
-
-  const unitPages = await getUnitPagesToProtect(api);
-  const templateCssPages = await getTemplateCssPagesToProtect(api);
-  const needToProtect = await collectMainPagePagesToProtect(api);
-  const allConvertPages = await getConvertBotPagesToProtect(api);
-  const convertPages = filterConvertBotPages(allConvertPages);
-
-  const errors = await protectPages(api, needToProtect, MAIN_PAGE_PROTECT, 'מופיע בעמוד הראשי');
-  const convertErrors = await protectPages(api, convertPages, MAIN_PAGE_PROTECT, 'דפי מפרט של בוט ההסבה');
-  const unitErrors = await protectPages(api, unitPages, UNIT_NAMESPACE_PROTECT, 'הגנה על מרחב יחידה');
-  const templateCssErrors = await protectPages(api, templateCssPages, UNIT_NAMESPACE_PROTECT, 'הגנה על דפי CSS במרחב תבנית');
-
-  await writeConvertPageLogs(api, allConvertPages, convertPages, convertErrors);
-  await writeUnitPageLogs(api, unitPages, unitErrors);
-  await writeTemplateCssPageLogs(api, templateCssPages, templateCssErrors);
-  await writeMainPageProtectionLogs(api, needToProtect, errors);
-  await writeCopyrightLogsIfNeeded(api);
-}
-
-export const main = botLoggerDecorator(protectBot, { botName: 'בוט הגנת דפים שמופיעים בעמוד הראשי' });

--- a/bot/admin/protect.ts
+++ b/bot/admin/protect.ts
@@ -39,7 +39,7 @@ const MODULE_NAMESPACE = 828;
 const TEMPLATE_CSS_SEARCH = 'contentmodel:sanitized-css';
 
 async function needProtectFromTitles(api: IWikiApi, titles: string[]): Promise<string[]> {
-  const promises: any[] = [];
+  const promises: Array<Promise<import('../types').PageInfo[]>> = [];
   for (let i = 0; i < titles.length; i += 50) {
     promises.push(api.info(titles.slice(i, i + 50)));
   }

--- a/bot/decorators/injectionDecorator.ts
+++ b/bot/decorators/injectionDecorator.ts
@@ -8,31 +8,33 @@ const injetionDictionary = {
   wikiApi: () => WikiApi(),
 } satisfies Record<keyof CallbackArgs, (...args: any[]) => any>;
 
-const implemtationDictionary: Partial<Record<keyof CallbackArgs, any>> = {};
+const implemtationDictionary: Partial<CallbackArgs> = {};
 
 export default function injectionDecorator<R>(
-  cb: (args?: CallbackArgs) => R,
+  cb: (args: CallbackArgs) => R,
   overrideInjetionDictionary?: typeof injetionDictionary, // For testing
   overrideImplemtationDictionary?: typeof implemtationDictionary, // For testing
 ) {
   const currentImplemtationDictionary = overrideImplemtationDictionary ?? implemtationDictionary;
   const currentInjetionDictionary = overrideInjetionDictionary ?? injetionDictionary;
-  return async function injection(): Promise<R> {
+  return async function injection(): Promise<R | undefined> {
     let actualArgs: CallbackArgs | null = null;
     if (cb.length > 0) {
       const [callbackArgs] = getArguments(cb);
       if (callbackArgs instanceof Array) {
-        const argsDictoary = {} satisfies CallbackArgs;
+        const argsDictoary: CallbackArgs = {};
         callbackArgs.forEach((arg) => {
           if (arg in currentInjetionDictionary) {
-            argsDictoary[arg] = currentImplemtationDictionary[arg] ?? currentInjetionDictionary[arg]();
-            currentImplemtationDictionary[arg] = argsDictoary[arg];
+            const injectionKey = arg as keyof CallbackArgs;
+            argsDictoary[injectionKey] = currentImplemtationDictionary[injectionKey]
+              ?? currentInjetionDictionary[injectionKey]();
+            currentImplemtationDictionary[injectionKey] = argsDictoary[injectionKey];
           }
         });
         actualArgs = argsDictoary;
       }
     }
 
-    return cb(actualArgs ?? undefined);
+    return actualArgs ? cb(actualArgs) : (cb as () => R)();
   };
 }

--- a/bot/global.d.ts
+++ b/bot/global.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable no-var, vars-on-top */
+
+declare global {
+  var continueObject: Record<string, string> | string | undefined;
+  var injetionDictionary: { wikiApi: (...args: unknown[]) => unknown } | undefined;
+}
+
+export {};

--- a/bot/indexesBot/index.ts
+++ b/bot/indexesBot/index.ts
@@ -21,6 +21,11 @@ type IndexData = {
   indexStocks: string[];
 };
 
+type SupportedIndex = {
+  template?: string;
+  category: string;
+};
+
 async function getCompanysData(api: IWikiApi, templateName: string) {
   const { content } = await api.articleContent(templateName);
   const templateData = findTemplate(content, '#switch: {{{ID}}}', templateName);
@@ -87,13 +92,13 @@ async function getIndexes(api: IWikiApi) {
   };
 }
 
-async function getSupportedIndexes(api: IWikiApi): Promise<Record<string, { template: string, category: string }>> {
+async function getSupportedIndexes(api: IWikiApi): Promise<Record<string, SupportedIndex>> {
   const { content } = await api.articleContent(companyIndexesTemplatesBase);
   const tables = parseTableText(content);
   const { rows } = tables[0];
   return rows
     .filter((row) => row.fields.length === 2)
-    .reduce((acc, row) => {
+    .reduce<Record<string, SupportedIndex>>((acc, row) => {
       const templateName = row.fields[1].toString().match(/\{\{תב\|(.*)\}\}/)?.[1];
       const category = row.fields[1].toString().match(/\[\[:קטגוריה:(.*)\]\]/)?.[1];
       acc[row.fields[0].toString()] = {
@@ -114,7 +119,7 @@ async function updateCompanyIndexes(api: IWikiApi, companyIndexesDict: Record<st
   const newData = Object.entries(companyIndexesDict).map(([companyId, indexes]) => {
     const companyIndexesTemplates = indexes
       .map((index) => suppurtedIndexes[index])
-      .filter((index) => index && index.template)
+      .filter((index): index is SupportedIndex & { template: string } => Boolean(index?.template))
       .map(({ category, template }) => `{{${template}}} ${category ? `[[קטגוריה:${category}]]` : ''}`);
     return [companyId, companyIndexesTemplates.join(' ')];
   });

--- a/bot/interwikiLinks/index.ts
+++ b/bot/interwikiLinks/index.ts
@@ -55,7 +55,7 @@ export function parseParamValidatorError(text: string): ParamValidatorError | nu
 
 export function getParamValidatorErrors(parsedContent: string): ParamValidatorError[] {
   return Array.from(new JSDOM(parsedContent).window.document.querySelectorAll(VALIDATOR_ERROR_SELECTOR))
-    .map((errorElement: HTMLElement) => parseParamValidatorError(errorElement.textContent))
+    .map((errorElement) => parseParamValidatorError(errorElement.textContent))
     .filter((error): error is ParamValidatorError => error != null);
 }
 

--- a/bot/ironSwords/index.ts
+++ b/bot/ironSwords/index.ts
@@ -8,7 +8,7 @@ import { logger } from '../utilities/logger';
 const baseTemplatePageName = 'תבנית:אבדות במלחמת חרבות ברזל';
 const templatePageName = `${baseTemplatePageName}/נתונים`;
 
-const keysMapping = {
+const keysMapping: Record<string, string> = {
   חיילים: 'soldiersKilled',
   'חיילים בעזה': 'soldiersKilledManeuver',
   'חיילים פצועים': 'soldiersWounded',
@@ -25,7 +25,7 @@ const keysMapping = {
   // 'חטופים ששוחררו': 'שוחררו או חולצו',
 };
 
-function replaceData(content: string, rows: string[], fieldName: string, newData?: number): string {
+function replaceData(content: string, rows: string[], fieldName: string, newData?: number | null): string {
   const templateRow = rows.find((row) => row.startsWith(`|${fieldName}=`) || row.startsWith(`| ${fieldName}=`));
   if (!templateRow || !newData) {
     return content;
@@ -61,7 +61,7 @@ export default async function ironSwordsBot() {
     const rows = content.split('\n').filter((row) => row.trim().startsWith('|'));
     let newContent = content;
     Object.entries(keysMapping).forEach(([key, value]) => {
-      newContent = replaceData(newContent, rows, key, allData[value]);
+      newContent = replaceData(newContent, rows, key, allData[value as keyof typeof allData]);
     });
     if (newContent === content) {
       console.log('No changes');

--- a/bot/scripts/oneTime/interwikiConverter.ts
+++ b/bot/scripts/oneTime/interwikiConverter.ts
@@ -7,7 +7,7 @@ const SEARCH_PATTERN = `${BASE_SEARCH_PATTERN}([^]|]+)\\|[א-ת-' ]+'\\]\\]\\)\\
 const regex = new RegExp(SEARCH_PATTERN.replaceAll('^]', '^\\]'), 'gi');
 const SUMMARY = 'הסבת קישורי בינוויקי לתבנית קישור שפה';
 
-const langugageCodeToLanguageName = {
+const langugageCodeToLanguageName: Record<string, string> = {
   ab: 'אבחזית',
   ady: 'אדיגית',
   udm: 'אודמורטית',

--- a/bot/scripts/oneTime/latestMigrations/nrgTemplate.ts
+++ b/bot/scripts/oneTime/latestMigrations/nrgTemplate.ts
@@ -119,7 +119,7 @@ async function generalLinkConverter(generalLink: CiteNewsTemplate | GeneralLinkT
     return '';
   }
   const date = generalLinkData?.['תאריך'] ?? citeNews?.['access-date'] ?? '';
-  const otherData = generalLink['מידע נוסף'] ?? '';
+  const otherData = 'מידע נוסף' in generalLink ? generalLink['מידע נוסף'] ?? '' : '';
   const otherWords = (otherData || date) ? `${date}${(date && otherData) ? ', ' : ''}${otherData}` : '';
 
   const title = generalLinkData?.['כותרת'] || citeNews?.title || '';

--- a/bot/scripts/oneTime/soldierAndPolicemanTypes.ts
+++ b/bot/scripts/oneTime/soldierAndPolicemanTypes.ts
@@ -384,7 +384,7 @@ const pages = [
   'אמברוז ברנסייד',
   'ניקולאי האראלמביה',
 ];
-const typeMapping = {
+const typeMapping: Record<string, string> = {
   חייל: 'צבאי',
   חיילת: 'צבאי',
   שוטר: 'משטרתי',

--- a/bot/scripts/oneTime/sportCategories.ts
+++ b/bot/scripts/oneTime/sportCategories.ts
@@ -20,7 +20,7 @@ async function main() {
   const allcategories: Category[] = [];
   do {
     res = await generator.next();
-    res?.value.query.allcategories.forEach((page) => {
+    res?.value.query.allcategories.forEach((page: { '*': string, size: number }) => {
       const name: string = page['*'];
       allcategories.push({
         name,

--- a/bot/scripts/oneTime/templatesDates/kanDates.ts
+++ b/bot/scripts/oneTime/templatesDates/kanDates.ts
@@ -3,7 +3,7 @@ import { getLocalDate } from '../../../utilities';
 import { getAttr, getMetaValue, getSchemaData } from '../../../scraping';
 import templateDates from './templateDates';
 
-const sectionDict = {
+const sectionDict: Record<string, string> = {
   podcast: 'Podcast/item.aspx?pid=',
   program: 'Program/?catId=',
   radio: 'Radio/item.aspx?pid=',

--- a/bot/scripts/oneTime/templatesDates/makoDates.ts
+++ b/bot/scripts/oneTime/templatesDates/makoDates.ts
@@ -22,7 +22,7 @@ async function getDateFromPage(id: string, title: string, section?: string) {
 }
 
 const TEMPLATE_NAME = 'Mako';
-const dataToDate = (data) => {
+const dataToDate = (data: string[]) => {
   const [,, id, section, date] = data;
   return {
     id,

--- a/bot/scripts/oneTime/templatesDates/nrgDates.ts
+++ b/bot/scripts/oneTime/templatesDates/nrgDates.ts
@@ -22,7 +22,7 @@ async function getDateFromPage(id: string, title: string, section?: string) {
 }
 
 const TEMPLATE_NAME = 'Nrg';
-const dataToDate = (data) => {
+const dataToDate = (data: string[]) => {
   const [,, id, date, section, art] = data;
   return {
     id: `${art ?? ''}/${id}`,

--- a/bot/scripts/oneTime/wiktionary/articleTemplateCleanup.ts
+++ b/bot/scripts/oneTime/wiktionary/articleTemplateCleanup.ts
@@ -113,7 +113,7 @@ export default async function wikitionaryArticleTemplateCleanup() {
     console.log('pagesForCleanup', pagesForCleanup.length);
   }
 }
-const resultsDict = {};
+const resultsDict: Record<string, number> = {};
 export async function cleanupArticles() {
   const baseApi = BaseWikiApi({
     ...defaultConfig,

--- a/bot/scripts/oneTime/wiktionary/fixCiteTemplateErrors.ts
+++ b/bot/scripts/oneTime/wiktionary/fixCiteTemplateErrors.ts
@@ -15,7 +15,7 @@ const TOSEFTA_CITE_TEMPLATE = 'צט/תוספתא';
 const MIDRASH_CITE_TEMPLATE = 'צט/מדרש';
 const YONATAN_CITE_TEMPLATE = 'צט/יהונתן';
 const TARGUM_CITE_TEMPLATE = 'צט/תרגום';
-const replaces = {
+const replaces: Record<string, string> = {
   ביכורים: 'בכורים',
   ידיים: 'ידים',
   מקוואות: 'מקואות',

--- a/bot/scripts/ynetLinkToTemplate.ts
+++ b/bot/scripts/ynetLinkToTemplate.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { WikiLink } from '../wiki/wikiLinkParser';
-import { GeneralLinkTemplateData } from './types';
+import { CiteNewsTemplate, GeneralLinkTemplateData } from './types';
 import { linksToTemplates } from './utils';
 import { getAttr, getMetaValue, getSchemaData } from '../scraping';
 import { getLocalDate } from '../utilities';
@@ -62,7 +62,10 @@ async function getArticleData(url: string, linkText: string): Promise<PageData |
   }
 }
 
-async function generalLinkConverter(generalLink: GeneralLinkTemplateData) {
+async function generalLinkConverter(generalLink: GeneralLinkTemplateData | CiteNewsTemplate) {
+  if (!('כתובת' in generalLink)) {
+    return null;
+  }
   const url = generalLink['כתובת'];
   const match = url?.match(articleRegex);
   const articleId = match?.[1] ?? url?.match(generalRegex)?.[1] ?? '';

--- a/bot/tag-bot/index.ts
+++ b/bot/tag-bot/index.ts
@@ -293,7 +293,7 @@ async function handleNotification(
     console.log({ commentRes });
     return;
   }
-  const action = actions[command];
+  const action = actions[command as keyof typeof actions];
   await action(api, notification);
 }
 

--- a/bot/types.ts
+++ b/bot/types.ts
@@ -36,6 +36,7 @@ export type PageInfo = {
   pageid?: number;
   title?: string;
   invalidreason?: string;
+  protection?: { type: string, level: string, expiry: string }[];
 }
 
 export type WikiPage = {

--- a/bot/wiki/WikiApi.ts
+++ b/bot/wiki/WikiApi.ts
@@ -17,7 +17,7 @@ export interface IWikiApi {
   request(path: string, method?: string, data?: Record<string, any>): Promise<any>;
   continueQuery(path: string, resultSelector?: (result: any) => any[], continueObject?: Record<string, string>):
     AsyncGenerator<any, void, void>;
-  recursiveSubCategories(category: string, limit?: number): AsyncGenerator<WikiPage, WikiPage, void>;
+  recursiveSubCategories(category: string, limit?: number): AsyncGenerator<WikiPage, void, void>;
   backlinksTo(target: string, namespace?: string): AsyncGenerator<WikiPage[], void, void>;
   edit(
     articleTitle: string, summary: string, content: string, baseRevId: number, newSectionTitle?: string, minor?: boolean
@@ -356,7 +356,7 @@ export default function WikiApi(baseWikiApi = BaseWikiApi(defaultConfig)): IWiki
     category: string,
     limit = 500,
     seen = new Set<string>(),
-  ) {
+  ): AsyncGenerator<WikiPage, void, void> {
     const generator = listCategory(category, limit, 'subcat');
 
     for await (const subCategory of generator) {

--- a/bot/wiki/newTemplateParser.ts
+++ b/bot/wiki/newTemplateParser.ts
@@ -50,7 +50,7 @@ export function findTemplate(text: string, templateName: string, title: string):
 }
 
 export function getTemplateKeyValueData(templateText: string): Record<string, string> {
-  const obj = {};
+  const obj: Record<string, string> = {};
   if (templateText) {
     let currIndex = templateText.indexOf('|') + 1;
     if (currIndex === 0) {

--- a/bot/yearly-report/company.ts
+++ b/bot/yearly-report/company.ts
@@ -56,25 +56,25 @@ const currencyDict: Record<string, CurrencyCode> = {
 export default class Company {
   name: string;
 
-  mayaId: string;
+  mayaId = '';
 
-  mayaDataForWiki: Record<string, any>;
+  mayaDataForWiki: Record<string, any> = {};
 
-  wikiTemplateData: Record<string, any>;
+  wikiTemplateData: Record<string, any> = {};
 
-  isContainsTemplate: boolean;
+  isContainsTemplate = false;
 
-  articleText: string;
+  articleText = '';
 
-  reference: string;
+  reference = '';
 
-  templateText: string;
+  templateText = '';
 
-  templateData: Record<string, any>;
+  templateData: Record<string, any> = {};
 
-  newArticleText: string;
+  newArticleText = '';
 
-  hasData: boolean;
+  hasData = false;
 
   companyId: string;
 
@@ -82,7 +82,7 @@ export default class Company {
 
   revisionSize: number;
 
-  revisionId: number;
+  revisionId = 0;
 
   api: IWikiApi;
 
@@ -124,9 +124,10 @@ export default class Company {
       rowsField = 'CurrPeriodValue';
     }
     mayaData.AllRows.forEach((row) => {
-      mayaDetails.set(row.Name, row[rowsField]);
+      mayaDetails.set(row.Name, row[rowsField as keyof typeof row]);
     });
-    const mayaYear = mayaData[periodField].Year;
+    const mayaPeriod = periodField === 'CurrentPeriod' ? mayaData.CurrentPeriod : mayaData.PreviousYear;
+    const mayaYear = mayaPeriod.Year;
 
     this.appendMayaData(mayaDetails, mayaYear);
     this.appendWikiData(wikiData);

--- a/testConfig/mocks/wikiApi.mock.ts
+++ b/testConfig/mocks/wikiApi.mock.ts
@@ -18,7 +18,7 @@ export default function WikiApiMock(base: Partial<Mocked<IWikiApi>> = {}): Mocke
       ) => AsyncGenerator<any, any, unknown>
       >(),
     recursiveSubCategories: base.recursiveSubCategories
-      ?? jest.fn<(category: string, limit?: number) => AsyncGenerator<WikiPage, WikiPage, void>>(),
+      ?? jest.fn<(category: string, limit?: number) => AsyncGenerator<WikiPage, void, void>>(),
     backlinksTo:
       base.backlinksTo
       ?? jest.fn<(target: string, namespace?: string) => AsyncGenerator<WikiPage[], void, void>>(),
@@ -103,7 +103,7 @@ export default function WikiApiMock(base: Partial<Mocked<IWikiApi>> = {}): Mocke
     getNotifications: base.getNotifications ?? jest.fn<() => Promise<any>>(),
     addComment: base.addComment
       ?? jest.fn<(page: string, summary: string, content: string, commentid: string) => Promise<any>>(),
-    allPages: base.allPages ?? jest.fn<(namespace: number) => AsyncGenerator<WikiPage[], void, void>>(),
+    allPages: base.allPages ?? jest.fn<(namespace?: number, from?: string) => AsyncGenerator<WikiPage[], void, void>>(),
     getParsedContent: base.getParsedContent ?? jest.fn<(title: string) => Promise<string>>(),
     getUserGroups: base.getUserGroups ?? jest.fn<(username: string) => Promise<string[]>>(),
     recentChanges: base.recentChanges ?? jest.fn<(namespaces: number[], endTimestamp: string, limit?: number,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,8 +7,10 @@
         "esModuleInterop": true,
         "strictNullChecks": true,
         "resolveJsonModule": true,
+        "rootDir": "bot",
         "outDir": "dist",
-        "strict": false
+        "strict": true,
+        "useUnknownInCatchVariables": false
     },
     "include": ["bot"],
     "exclude": ["bot/__tests__"]

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,7 +6,9 @@
         "esModuleInterop": true,
         "strictNullChecks": true,
         "resolveJsonModule": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "strict": true,
+        "useUnknownInCatchVariables": false
     },
     "include": [
         "bot",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
         "resolveJsonModule": true,
         "outDir": "dist",
         "sourceMap": true,
-        "strict": false
+        "strict": true,
+        "useUnknownInCatchVariables": false
     },
     "include": ["bot", "testConfig", "xmlbot"]
 }

--- a/xmlbot/xml2js.d.ts
+++ b/xmlbot/xml2js.d.ts
@@ -1,0 +1,3 @@
+declare module 'xml2js' {
+  export function parseStringPromise(xml: string): Promise<any>;
+}


### PR DESCRIPTION
## Summary

- enable `strict: true` in the main, build, and ESLint TypeScript configurations
- fix strict-mode errors across production code, one-time scripts, tests, and mocks
- add explicit object/index/callback/global types and initialize class fields
- add a local `xml2js` declaration so the root type-check can cover `xmlbot`
- set `rootDir` explicitly for the TypeScript 6 build

## Migration note

`useUnknownInCatchVariables` remains disabled as a temporary, explicit exception. Enabling it still exposes many repetitive error-handling issues, mostly in legacy one-time scripts; the rest of strict mode is enabled now without weakening `noImplicitAny`, strict function checks, or property initialization.

## Impact

The repository now type-checks and builds with strict mode. The fixes are type-focused and preserve the existing runtime behavior.

## Validation

- `npm run type-check`
- `npm run build`
- `npm run lint:test`
- `TZ=Asia/Jerusalem npm test` — 800 tests passed, 100% coverage
- `node --import tsx scripts/smoke-test.mjs`

CloudFormation validation could not run locally because this environment has no AWS credentials.