### PR TITLE
Fix TypeScript 6 production build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
         "esModuleInterop": true,
         "strictNullChecks": true,
         "resolveJsonModule": true,
+        "rootDir": "bot",
         "outDir": "dist",
         "strict": false
     },


### PR DESCRIPTION
Fixes the CD failure introduced by the TypeScript 6 upgrade.

TypeScript 6 requires an explicit `rootDir` when the inferred common source directory would affect the output layout. The production build only includes `bot`, so this sets `rootDir` to `bot`.

Validated locally with `npm run build`.