### PR TITLE
Fix Lambda cookie agent compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-sqs": "^3.1070.0",
         "@hebcal/core": "^6.6.0",
         "axios": "^1.18.1",
-        "axios-cookiejar-support": "^7.0.0",
+        "axios-cookiejar-support": "6.0.4",
         "find-hebrew-names": "^0.0.2",
         "jsdom": "^26.1.0",
         "openai": "^6.33.0",
@@ -5703,15 +5703,15 @@
       }
     },
     "node_modules/axios-cookiejar-support": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-7.0.0.tgz",
-      "integrity": "sha512-IpxfiGiEsHp3uj3fjtTiM2LjQGKF5Ig7gZSsVKTJ9RN6KZor17bEwU1ZgYMcrrT3qKP3pz1FdzufgHjtDxKIvg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-6.0.4.tgz",
+      "integrity": "sha512-4Bzj+l63eGwnWDBFdJHeGS6Ij3ytpyqvo//ocsb5kCLN/rKthzk27Afh2iSkZtuudOBkHUWWIcyCb4GKhXqovQ==",
       "license": "MIT",
       "dependencies": {
-        "http-cookie-agent": "^8.0.0"
+        "http-cookie-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/3846masa"
@@ -7627,36 +7627,27 @@
       "license": "MIT"
     },
     "node_modules/http-cookie-agent": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-8.0.0.tgz",
-      "integrity": "sha512-c5A2W4NXYRQR+ZOEA+nzLlWj0K7zXAG21UZaDKfZrFSlmmb1MMXBVDhQJNUNYkYJZwFi0ptlNu4r37tEM45tvg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.3.tgz",
+      "integrity": "sha512-EeZo7CGhfqPW6R006rJa4QtZZUpBygDa2HZH3DJqsTzTjyRE6foDBVQIv/pjVsxHC8z2GIdbB1Hvn9SRorP3WQ==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^9.0.0"
+        "agent-base": "^7.1.4"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/3846masa"
       },
       "peerDependencies": {
         "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "undici": "^7.0.0 || ^8.0.0"
+        "undici": "^7.0.0"
       },
       "peerDependenciesMeta": {
         "undici": {
           "optional": true
         }
-      }
-    },
-    "node_modules/http-cookie-agent/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/http-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docker-run": "sh ./build/wiki-bot-playwright/run.sh",
     "docker-test": "curl \"http://localhost:9000/2015-03-31/functions/function/invocations\" -d '{}'",
     "validate-cf": "tsx ./build/validate-cloudformation.ts",
-    "smoke-test": "tsx ./scripts/smoke-test.mjs",
+    "smoke-test": "NODE_OPTIONS='--no-experimental-require-module --no-experimental-detect-module' node --import tsx ./scripts/smoke-test.mjs",
     "test:ci": "npm run type-check && npm test && npm run lint:test && npm run smoke-test && npm run validate-cf",
     "rollback": "tsx --env-file=.env bot/scripts/rollback.ts",
     "experiments": "tsx --env-file=.env bot/experiments/index.ts"
@@ -33,12 +33,17 @@
     "@aws-sdk/client-sqs": "^3.1070.0",
     "@hebcal/core": "^6.6.0",
     "axios": "^1.18.1",
-    "axios-cookiejar-support": "^7.0.0",
+    "axios-cookiejar-support": "6.0.4",
     "find-hebrew-names": "^0.0.2",
     "jsdom": "^26.1.0",
     "openai": "^6.33.0",
     "playwright": "^1.61.0",
     "tough-cookie": "^6.0.1"
+  },
+  "overrides": {
+    "axios-cookiejar-support": {
+      "http-cookie-agent": "7.0.3"
+    }
   },
   "devDependencies": {
     "@aws-sdk/client-cloudformation": "^3.988.0",


### PR DESCRIPTION
## What changed

- Downgrade `axios-cookiejar-support` from 7.0.0 to 6.0.4.
- Pin its transitive `http-cookie-agent` dependency to 7.0.3, the last compatible release before it adopted ESM-only `agent-base@9`.
- Run the dependency smoke test with the same module flags AWS Lambda applies:
  - `--no-experimental-require-module`
  - `--no-experimental-detect-module`
- Invoke the TypeScript loader through `node --import tsx`, so the smoke test exercises Node directly.

## Root cause

`axios-cookiejar-support@7` installs `http-cookie-agent@8`, whose CommonJS output calls `require("agent-base")`. Its `agent-base@9` dependency is ESM-only. Standard Node.js 24 allows that through experimental `require(ESM)` support, but AWS Lambda disables that feature, causing `ERR_REQUIRE_ESM` during function initialization.

The previous smoke test ran on standard Node.js 24 without Lambda's disabled-feature flags, so the incompatible dependency graph loaded successfully in CI.

## Impact

Lambda functions can initialize again without enabling unsupported experimental runtime behavior. Future dependency upgrades that recreate this CommonJS-to-ESM dependency mismatch will fail the smoke test before deployment.

## Validation

- `npm run type-check`
- `npm test` — 800 tests passed, 100% reported coverage
- `npm run lint:test`
- `npm run smoke-test` with Lambda module flags
- `npm run build`
- `npm run test:ci` was run; all code checks and the smoke test passed. CloudFormation validation could not authenticate locally because AWS credentials are not available in the workspace.