### PR TITLE
Make wiki API identity configurable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,8 @@ jobs:
           CODE_BUCKET: ${{ secrets.CODE_BUCKET_NAME }}
           USER_NAME: ${{ secrets.WIKI_USER_NAME }}
           PASSWORD: ${{ secrets.WIKI_USER_PASSWORD }}
+          BASE_URL: ${{ vars.WIKI_BASE_URL || 'https://he.wikipedia.org' }}
+          BOT_NAME: ${{ vars.WIKI_BOT_NAME || 'Sapper-bot' }}
           PROTECT_USER_NAME: ${{ secrets.WIKI_PROTECT_USER_NAME }}
           PROTECT_PASSWORD: ${{ secrets.WIKI_PROTECT_USER_PASSWORD }}
           DELETE_USER_NAME: ${{ secrets.WIKI_DELETE_USER_NAME }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: ${{ vars.WIKI_BASE_URL || 'https://he.wikipedia.org' }}
+      BOT_NAME: ${{ vars.WIKI_BOT_NAME || 'Sapper-bot' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/bot/__tests__/botLoggerDecorator.test.ts
+++ b/bot/__tests__/botLoggerDecorator.test.ts
@@ -11,6 +11,8 @@ jest.unstable_mockModule('../wiki/WikiApi', () => ({
   default: () => moduleMockApi,
 }));
 
+process.env.BOT_NAME = 'Logger-bot';
+
 const { default: botLoggerDecorator } = await import('../decorators/botLoggerDecorator');
 
 describe('botLoggerDecorator', () => {
@@ -220,11 +222,11 @@ describe('botLoggerDecorator', () => {
 
     await decorated();
 
-    expect(mockApi.articleContent).toHaveBeenCalledWith('משתמש:Sapper-bot/לוג ריצות');
+    expect(mockApi.articleContent).toHaveBeenCalledWith('משתמש:Logger-bot/לוג ריצות');
 
     const editCall = mockApi.edit.mock.calls[0];
 
-    expect(editCall[0]).toBe('משתמש:Sapper-bot/לוג ריצות');
+    expect(editCall[0]).toBe('משתמש:Logger-bot/לוג ריצות');
   });
 
   it('should add signature at the end of logs', async () => {
@@ -300,7 +302,7 @@ describe('botLoggerDecorator', () => {
     await decorated();
 
     expect(moduleMockApi.login).toHaveBeenCalledWith();
-    expect(moduleMockApi.articleContent).toHaveBeenCalledWith('משתמש:Sapper-bot/לוג ריצות');
+    expect(moduleMockApi.articleContent).toHaveBeenCalledWith('משתמש:Logger-bot/לוג ריצות');
   });
 
   it('should log to console when NODE_ENV is development', () => {

--- a/bot/decorators/botLoggerDecorator.ts
+++ b/bot/decorators/botLoggerDecorator.ts
@@ -3,7 +3,7 @@ import { getLocalTimeAndDate } from '../utilities';
 import shabathProtectorDecorator from './shabathProtector';
 import { BotLoggerContext, loggerAsyncLocalStorage } from '../utilities/logger';
 
-const BOT_LOG_PAGE = 'משתמש:Sapper-bot/לוג ריצות';
+const BOT_LOG_PAGE = `משתמש:${process.env.BOT_NAME}/לוג ריצות`;
 
 const findNextHeadingNumber = (content: string, baseHeading: string): number => {
   const escapedHeading = baseHeading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/bot/wiki/BaseWikiApi.ts
+++ b/bot/wiki/BaseWikiApi.ts
@@ -6,8 +6,10 @@ import { baseLogin, getToken as getWikiToken } from './wikiLogin';
 import { IBaseWikiApi, WikiApiConfig } from '../types';
 import { logger } from '../utilities/logger';
 
+const wikiBaseUrl = process.env.BASE_URL;
+
 export const defaultConfig: Partial<WikiApiConfig> = {
-  baseUrl: 'https://he.wikipedia.org/w/api.php',
+  baseUrl: wikiBaseUrl && `${wikiBaseUrl}/w/api.php`,
   userName: process.env.USER_NAME,
   password: process.env.PASSWORD,
 };
@@ -20,17 +22,18 @@ function validateConfig(config: Partial<WikiApiConfig> = defaultConfig): config 
 }
 
 export default function BaseWikiApi(apiConfig: Partial<WikiApiConfig>): IBaseWikiApi {
+  const botName = process.env.BOT_NAME;
   const jar = new CookieJar();
   const client = wrapper(axios.create({
     jar,
     headers: {
-      'User-Agent': 'Sapper-bot/1.0 (https://he.wikipedia.org/wiki/User:Sapper-bot)',
+      'User-Agent': `${botName}/1.0 (${wikiBaseUrl}/wiki/User:${botName})`,
     },
   }));
 
   const actualConfig = { ...defaultConfig, ...apiConfig };
   let token: string;
-  if (!validateConfig(actualConfig)) {
+  if (!validateConfig(actualConfig) || !botName || !wikiBaseUrl) {
     throw new Error('Missing username or password');
   }
   const config = actualConfig; // Just for typescript

--- a/bot/wiki/WikidataSparql.ts
+++ b/bot/wiki/WikidataSparql.ts
@@ -1,7 +1,10 @@
+const wikiBaseUrl = process.env.BASE_URL;
+const botName = process.env.BOT_NAME;
+
 export async function querySparql(query: string): Promise<Record<string, string>[]> {
   const res = await fetch(`https://query.wikidata.org/sparql?query=${encodeURIComponent(query)}&format=json`, {
     headers: {
-      'User-Agent': 'Sapper-bot/1.0 (https://he.wikipedia.org/wiki/User:Sapper-bot)',
+      'User-Agent': `${botName}/1.0 (${wikiBaseUrl}/wiki/User:${botName})`,
     },
   });
   if (!res.ok) {

--- a/build/t01.cf.yaml
+++ b/build/t01.cf.yaml
@@ -12,6 +12,12 @@ Parameters:
   WikiPassword:
     Description: The password of wiki user.
     Type: String
+  WikiBaseUrl:
+    Description: The base URL of the wiki.
+    Type: String
+  WikiBotName:
+    Description: The name of the wiki bot.
+    Type: String
   WikiProtectUserName:
     Description: The name of wiki protect user.
     Type: String
@@ -50,6 +56,8 @@ Globals:
       Variables:
         USER_NAME: !Ref WikiUserName
         PASSWORD: !Ref WikiPassword
+        BASE_URL: !Ref WikiBaseUrl
+        BOT_NAME: !Ref WikiBotName
 
 Resources:
   MarketValueFunction:
@@ -253,6 +261,8 @@ Resources:
         Variables:
           USER_NAME: !Ref WikiUserName
           PASSWORD: !Ref WikiPassword
+          BASE_URL: !Ref WikiBaseUrl
+          BOT_NAME: !Ref WikiBotName
       EphemeralStorage:
         Size: 2048
 
@@ -337,6 +347,8 @@ Resources:
         Variables:
           USER_NAME: !Ref WikiUserName
           PASSWORD: !Ref WikiPassword
+          BASE_URL: !Ref WikiBaseUrl
+          BOT_NAME: !Ref WikiBotName
       ImageConfig:
         Command:
           - dist/tag-bot/playwrightCheck/index.main

--- a/build/t02.cf.yaml
+++ b/build/t02.cf.yaml
@@ -14,6 +14,12 @@ Parameters:
   WikiPassword:
     Description: The password of wiki user.
     Type: String
+  WikiBaseUrl:
+    Description: The base URL of the wiki.
+    Type: String
+  WikiBotName:
+    Description: The name of the wiki bot.
+    Type: String
 
 Globals:
   Function:
@@ -31,6 +37,8 @@ Globals:
       Variables:
         USER_NAME: !Ref WikiUserName
         PASSWORD: !Ref WikiPassword
+        BASE_URL: !Ref WikiBaseUrl
+        BOT_NAME: !Ref WikiBotName
 
 Resources:
   KineretLevelFunction:

--- a/build/update-env.ts
+++ b/build/update-env.ts
@@ -109,6 +109,12 @@ async function main() {
       ParameterKey: 'WikiPassword',
       ParameterValue: process.env.PASSWORD,
     }, {
+      ParameterKey: 'WikiBaseUrl',
+      ParameterValue: process.env.BASE_URL,
+    }, {
+      ParameterKey: 'WikiBotName',
+      ParameterValue: process.env.BOT_NAME,
+    }, {
       ParameterKey: 'WikiProtectUserName',
       ParameterValue: process.env.PROTECT_USER_NAME,
     }, {
@@ -153,6 +159,12 @@ async function main() {
     }, {
       ParameterKey: 'WikiPassword',
       ParameterValue: process.env.PASSWORD,
+    }, {
+      ParameterKey: 'WikiBaseUrl',
+      ParameterValue: process.env.BASE_URL,
+    }, {
+      ParameterKey: 'WikiBotName',
+      ParameterValue: process.env.BOT_NAME,
     }],
     ['CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
   );


### PR DESCRIPTION
## What changed

- Read the wiki origin from `BASE_URL` and keep `/w/api.php` hard-coded in the API client.
- Build the MediaWiki API and Wikidata SPARQL `User-Agent` values from `BOT_NAME` and `BASE_URL`.
- Use `BOT_NAME` for the bot logger's wiki log page.
- Pass both values through CI, CD, the deployment script, and both CloudFormation stacks.
- Include the variables in the two container-based Lambda functions that do not inherit SAM globals.

GitHub Actions reads `vars.WIKI_BASE_URL` and `vars.WIKI_BOT_NAME`. Until those repository/environment variables are configured, it falls back to `https://he.wikipedia.org` and `Sapper-bot`.

## Impact

The bot can target a different MediaWiki installation and identify a different bot without changing source code.

## Validation

- Rebased onto `master`; the PR contains one coherent commit.
- Type checking passed.
- All 800 unit tests passed with 100% coverage.
- Smoke tests and ESLint passed.