### PR TITLE
Use BOT_NAME across runtime bot identity

### DIFF
--- a/bot/__tests__/TagBotArchive.test.ts
+++ b/bot/__tests__/TagBotArchive.test.ts
@@ -6,6 +6,8 @@ import { IWikiApi } from '../wiki/WikiApi';
 import WikiApiMock from '../../testConfig/mocks/wikiApi.mock';
 import { Mocked } from '../../testConfig/mocks/types';
 
+const botName = process.env.BOT_NAME;
+
 describe('archiveParagraph', () => {
   let api: Mocked<IWikiApi>;
 
@@ -121,7 +123,7 @@ describe('archiveParagraph', () => {
     });
 
     const archiveBox = '{{תיבת ארכיון|[[archiveBoxContent]]}}';
-    const paragraphContent = `paragraphContent\n:@[[משתמש:Sapper-bot]] ארכב: ${userSign}`;
+    const paragraphContent = `paragraphContent\n:@[[משתמש:${botName}]] ארכב: ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson');
 
@@ -161,7 +163,7 @@ describe('archiveParagraph', () => {
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] ארכב ל: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
+:@[[משתמש:${botName}]] ארכב ל: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson', ['ל', '[[שיחת תבנית:ספרינגפילד]]']);
 
@@ -209,7 +211,7 @@ ${statusTemplate}
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] ארכב ל: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
+:@[[משתמש:${botName}]] ארכב ל: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson', ['ל', '[[שיחת תבנית:ספרינגפילד]]']);
 
@@ -255,7 +257,7 @@ ${statusTemplate}
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] ארכב ל: שיחת תבנית:ספרינגפילד ${userSign}`;
+:@[[משתמש:${botName}]] ארכב ל: שיחת תבנית:ספרינגפילד ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson', ['ל', 'שיחת תבנית:ספרינגפילד']);
 
@@ -302,7 +304,7 @@ ${statusTemplate}
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] ארכב: שיחת תבנית:ספרינגפילד ${userSign}`;
+:@[[משתמש:${botName}]] ארכב: שיחת תבנית:ספרינגפילד ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson', ['wrong', 'שיחת תבנית:ספרינגפילד']);
 
@@ -327,7 +329,7 @@ paragraphContent
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] ארכב: יעד: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
+:@[[משתמש:${botName}]] ארכב: יעד: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
     const pageContent = `${archiveBox}\n${paragraphContent}`;
     const result = await archiveParagraph(api, pageContent, 123, 'pageTitle', paragraphContent, 'summary', 'Homer Simpson', ['ל', '[[שיחת תבנית:ספרינגפילד]]']);
 

--- a/bot/__tests__/TagBotMove.test.ts
+++ b/bot/__tests__/TagBotMove.test.ts
@@ -6,6 +6,8 @@ import { IWikiApi } from '../wiki/WikiApi';
 import WikiApiMock from '../../testConfig/mocks/wikiApi.mock';
 import { Mocked } from '../../testConfig/mocks/types';
 
+const botName = process.env.BOT_NAME;
+
 describe('moveTo', () => {
   let api: Mocked<IWikiApi>;
 
@@ -32,7 +34,7 @@ describe('moveTo', () => {
     const paragraphContent = `==paragraph headline==
 ${statusTemplate}
 paragraphContent
-:@[[משתמש:Sapper-bot]] העבר: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
+:@[[משתמש:${botName}]] העבר: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
     const pageContent = `some content before\n${paragraphContent}\nsome content after`;
 
     const result = await moveTo(
@@ -78,7 +80,7 @@ paragraphContent
 
     const paragraphContent = `==paragraph headline==
 paragraphContent
-:@[[משתמש:Sapper-bot]] העבר: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
+:@[[משתמש:${botName}]] העבר: [[שיחת תבנית:ספרינגפילד]] ${userSign}`;
     const pageContent = `${paragraphContent}`;
 
     const result = await moveTo(

--- a/bot/__tests__/interwikiLinks.test.ts
+++ b/bot/__tests__/interwikiLinks.test.ts
@@ -66,7 +66,7 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.create).toHaveBeenCalledWith(
-      'user:sapper-bot/קישורי שפה - הפניות - ריצה 5',
+      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות - ריצה 5`,
       'תיקון קישורי שפה',
       '\n\n* [[Page1]]: <nowiki>{{|}}</nowiki> - [[::]] - דולג: לא נמצאו שגיאות',
     );
@@ -83,7 +83,7 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.edit).toHaveBeenCalledWith(
-      'user:sapper-bot/קישורי שפה - הפניות - ריצה 5',
+      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות - ריצה 5`,
       'תיקון קישורי שפה',
       '\n\n* [[Page1]]: <nowiki>{{|}}</nowiki> - [[::]] - דולג: לא נמצאו שגיאות',
       1,
@@ -103,7 +103,7 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.edit).toHaveBeenCalledWith(
-      'user:sapper-bot/קישורי שפה - הפניות - ריצה 5',
+      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות - ריצה 5`,
       'תיקון קישורי שפה',
       expect.stringContaining('דולג: custom failure'),
       1,
@@ -1228,7 +1228,7 @@ describe('runSinglePage', () => {
     const logEditCall = api.edit.mock.calls.at(-1);
 
     expect(logEditCall).toBeDefined();
-    expect(logEditCall?.[0]).toBe('user:sapper-bot/קישורי שפה - הפניות - ריצה 5');
+    expect(logEditCall?.[0]).toBe(`user:${process.env.BOT_NAME}/קישורי שפה - הפניות - ריצה 5`);
     expect(logEditCall?.[1]).toBe('תיקון קישורי שפה');
     expect(logEditCall?.[2]).toStrictEqual(expect.stringContaining('* [[TestPage]]: <nowiki>{{אנג|Google}}</nowiki> - [[:en:Google]] ← [[:en:NewGoogle]] - דולג: התבנית המתאימה לא נמצאה'));
     expect(logEditCall?.[3]).toBe(1);

--- a/bot/__tests__/utilities.test.ts
+++ b/bot/__tests__/utilities.test.ts
@@ -458,7 +458,7 @@ describe('convertContentToWikiPage', () => {
             contentformat: 'text/x-wiki',
           },
         },
-        user: 'Sapper-bot',
+        user: process.env.BOT_NAME as string,
         size: content.length,
       }],
     };

--- a/bot/admin/deleteRedirects.ts
+++ b/bot/admin/deleteRedirects.ts
@@ -118,8 +118,8 @@ export default async function deleteBot() {
   logs.push(...(await deleteRedirects(api, 3, 1, ['הפניה ממרחב שיחת משתמש למרחב שיחה'], 30)));
   logs.push(...(await deleteRedirects(api, 0, 2, ['הפניה ממרחב ראשי למרחב משתמש'])));
   logs.push(...(await deleteRedirects(api, 0, 118, ['הפניה ממרחב ראשי למרחב טיוטה'])));
-  await writeAdminBotLogs(api, logs, 'משתמש:Sapper-bot/מחיקת הפניות חוצות מרחבי שם');
-  await writeAdminBotLogs(api, convertLogs, 'משתמש:Sapper-bot/מחיקת דפי פלט של בוט ההסבה');
+  await writeAdminBotLogs(api, logs, `משתמש:${process.env.BOT_NAME}/מחיקת הפניות חוצות מרחבי שם`);
+  await writeAdminBotLogs(api, convertLogs, `משתמש:${process.env.BOT_NAME}/מחיקת דפי פלט של בוט ההסבה`);
 }
 
 export const main = botLoggerDecorator(deleteBot, { botName: 'בוט מחיקת הפניות' });

--- a/bot/admin/log.ts
+++ b/bot/admin/log.ts
@@ -5,7 +5,7 @@ import { getParagraphContent, getUsersFromTagParagraph, Paragraph } from '../wik
 import { getInnerLinks } from '../wiki/wikiLinkParser';
 import { ArticleLog } from './types';
 
-const tagsPage = 'משתמש:Sapper-bot/תיוג משתמשים';
+const tagsPage = `משתמש:${process.env.BOT_NAME}/תיוג משתמשים`;
 
 function isParagraphArray(logs: ArticleLog[] | Paragraph[]): logs is Paragraph[] {
   const firstElement = logs[0];

--- a/bot/admin/protect.ts
+++ b/bot/admin/protect.ts
@@ -227,7 +227,7 @@ async function writeConvertPageLogs(
     convertErrors,
     (title) => !convertPages.includes(title),
   );
-  await writeAdminBotLogs(api, logs, 'משתמש:Sapper-bot/הגנת דפי מפרט של בוט ההסבה');
+  await writeAdminBotLogs(api, logs, `משתמש:${process.env.BOT_NAME}/הגנת דפי מפרט של בוט ההסבה`);
 }
 
 async function writeUnitPageLogs(api: IWikiApi, unitPages: string[], unitErrors: string[]) {
@@ -235,7 +235,7 @@ async function writeUnitPageLogs(api: IWikiApi, unitPages: string[], unitErrors:
     return;
   }
   const logs = articleLogsFromTitles(unitPages, unitErrors);
-  await writeAdminBotLogs(api, logs, 'משתמש:Sapper-bot/הגנת דפי מרחב יחידה');
+  await writeAdminBotLogs(api, logs, `משתמש:${process.env.BOT_NAME}/הגנת דפי מרחב יחידה`);
 }
 
 async function writeTemplateCssPageLogs(api: IWikiApi, templateCssPages: string[], templateCssErrors: string[]) {
@@ -243,7 +243,7 @@ async function writeTemplateCssPageLogs(api: IWikiApi, templateCssPages: string[
     return;
   }
   const logs = articleLogsFromTitles(templateCssPages, templateCssErrors);
-  await writeAdminBotLogs(api, logs, 'משתמש:Sapper-bot/הגנת דפי CSS במרחב תבנית');
+  await writeAdminBotLogs(api, logs, `משתמש:${process.env.BOT_NAME}/הגנת דפי CSS במרחב תבנית`);
 }
 
 async function writeMainPageProtectionLogs(
@@ -256,7 +256,7 @@ async function writeMainPageProtectionLogs(
     return;
   }
   const logs = articleLogsFromTitles(needToProtect, errors);
-  await writeAdminBotLogs(api, [...logs, ...needProtectLogs], 'משתמש:Sapper-bot/הגנת דפים שמופיעים בעמוד הראשי');
+  await writeAdminBotLogs(api, [...logs, ...needProtectLogs], `משתמש:${process.env.BOT_NAME}/הגנת דפים שמופיעים בעמוד הראשי`);
 }
 
 async function writeCopyrightLogsIfNeeded(api: IWikiApi) {
@@ -265,7 +265,7 @@ async function writeCopyrightLogsIfNeeded(api: IWikiApi) {
   }
   const pagesWithCopyrightIssues = await pagesWithCopyrightIssuesInMainPage();
   if (pagesWithCopyrightIssues.length) {
-    await writeAdminBotLogs(api, pagesWithCopyrightIssues, 'משתמש:Sapper-bot/זכויות יוצרים');
+    await writeAdminBotLogs(api, pagesWithCopyrightIssues, `משתמש:${process.env.BOT_NAME}/זכויות יוצרים`);
   }
 }
 

--- a/bot/interwikiLinks/index.ts
+++ b/bot/interwikiLinks/index.ts
@@ -14,7 +14,7 @@ import { getRedirectTargetFromContent } from '../wiki/redirectParser';
 import { WikiPage } from '../types';
 
 const CATEGORY_TITLE = 'קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה';
-const LOG_PAGE_TITLE = 'user:sapper-bot/קישורי שפה - הפניות - ריצה 5';
+const LOG_PAGE_TITLE = `user:${process.env.BOT_NAME}/קישורי שפה - הפניות - ריצה 5`;
 const EDIT_SUMMARY = 'תיקון קישורי שפה';
 const VALIDATOR_ERROR_SELECTOR = '.paramvalidator-error';
 const VALIDATOR_ERROR_REGEX = /שימוש בתבנית\s+(.+?)\s+עבור\s+"(.+?)"\s+בשפה\s+([a-z-]+)\s+אך ערך זה לא קיים בשפה זו/i;

--- a/bot/maintenance/archiveBot/index.ts
+++ b/bot/maintenance/archiveBot/index.ts
@@ -3,8 +3,8 @@ import WikiApi from '../../wiki/WikiApi';
 import ArchiveBotModel from './ArchiveBotModel';
 
 const pages = [
-  'משתמש:Sapper-bot/הגנת דפים שמופיעים בעמוד הראשי',
-  'משתמש:Sapper-bot/מחיקת הפניות חוצות מרחבי שם',
+  `משתמש:${process.env.BOT_NAME}/הגנת דפים שמופיעים בעמוד הראשי`,
+  `משתמש:${process.env.BOT_NAME}/מחיקת הפניות חוצות מרחבי שם`,
   'ויקיפדיה:בוט/בדיקת הפרת זכויות יוצרים',
   'ויקיפדיה:בוט/בדיקת הפרת זכויות יוצרים/לוג',
   'ויקיפדיה:בוט/בדיקת הפרת זכויות יוצרים/עריכות',
@@ -12,8 +12,8 @@ const pages = [
 ];
 
 const archiveBySignatureDatePages = [
-  'משתמש:Sapper-bot/אימיילים',
-  'משתמש:Sapper-bot/לוג ריצות',
+  `משתמש:${process.env.BOT_NAME}/אימיילים`,
+  `משתמש:${process.env.BOT_NAME}/לוג ריצות`,
 ];
 
 export default async function archiveBot() {

--- a/bot/tag-bot/actions/archive.ts
+++ b/bot/tag-bot/actions/archive.ts
@@ -2,10 +2,14 @@ import { findTemplate } from '../../wiki/newTemplateParser';
 import { IWikiApi } from '../../wiki/WikiApi';
 import { getInnerLink } from '../../wiki/wikiLinkParser';
 import { getArchiveTitle } from '../../utilities/archiveUtils';
+import { escapeRegex } from '../../utilities';
 
-const archiveCommandRegex = /^ *(:)*@\[\[(?:(?:משתמש|user):)?Sapper-bot(?:\|Sapper-bot)?\]\] +ארכב(\s+ל)?:.*/im;
-const archiveCommandRegexGlobal = /^ *(:)*@\[\[(?:(?:משתמש|user):)?Sapper-bot(?:\|Sapper-bot)?\]\] +ארכב(\s+ל)?:.*/gim;
-const moveCommandRegexGlobal = /^ *(:)*@\[\[(?:(?:משתמש|user):)?Sapper-bot(?:\|Sapper-bot)?\]\] +העבר:.*/gim;
+const botName = process.env.BOT_NAME as string;
+const escapedBotName = escapeRegex(botName);
+const botMentionPattern = `@\\[\\[(?:(?:משתמש|user):)?${escapedBotName}(?:\\|${escapedBotName})?\\]\\]`;
+const archiveCommandRegex = new RegExp(`^ *(:)*${botMentionPattern} +ארכב(\\s+ל)?:.*`, 'im');
+const archiveCommandRegexGlobal = new RegExp(`^ *(:)*${botMentionPattern} +ארכב(\\s+ל)?:.*`, 'gim');
+const moveCommandRegexGlobal = new RegExp(`^ *(:)*${botMentionPattern} +העבר:.*`, 'gim');
 
 async function innerMove(
   api: IWikiApi,

--- a/bot/tag-bot/gpt-bot/instructions.ts
+++ b/bot/tag-bot/gpt-bot/instructions.ts
@@ -1,9 +1,11 @@
+const botName = process.env.BOT_NAME;
+
 const instructions = `You are a helpful assistant that specializes only in Hebrew Wikipedia. You must only answer questions related to Hebrew Wikipedia. If a user asks anything outside this topic, politely decline and remind them that you only answer Hebrew Wikipedia-related questions.
-The Sapper-bot bot is designed to answer questions and discussions on the Hebrew Wikipedia, in accordance with the community's policies and procedures.
+The ${botName} bot is designed to answer questions and discussions on the Hebrew Wikipedia, in accordance with the community's policies and procedures.
 Its source code is available here: [https://github.com/EladHeller/wiki-bot GitHub]
 Information about the bot's actions is in the file bot-explain.txt
 The bot's code from GitHub is in the file code.zip
-The bot introduces itself as [[user:Sapper-bot]], built by [[User:החבלן]] on the Hebrew Wikipedia. It should be aware of the relevant policies and help pages on the Hebrew Wikipedia and use the Wikipedia policies found in the context files.
+The bot introduces itself as [[user:${botName}]], built by [[User:החבלן]] on the Hebrew Wikipedia. It should be aware of the relevant policies and help pages on the Hebrew Wikipedia and use the Wikipedia policies found in the context files.
 Note: In the \`wikipedia-policies.txt\` file, each section begins with a header in the format \`### [[ויקיפדיה:שם הדף]]\`, followed by two line breaks, then the content of that page.
 The bot must not answer questions about general Israeli politics, news, science, or non-Wikipedia technical topics — even if they seem tangentially related. It is not a general-purpose assistant.
 Avoid authoritative or personal tones. Use a neutral, helpful tone aligned with Wikipedia discussion norms.
@@ -25,10 +27,10 @@ The bot should answer in the language in which it was asked, with priority given
 
 Examples:
 User: האם כדאי לי לקנות מזגן חדש?
-Bot: אני מצטער, אני עונה רק על שאלות הקשורות בוויקיפדיה העברית וב-[[User:Sapper-bot|Sapper-bot]]
+Bot: אני מצטער, אני עונה רק על שאלות הקשורות בוויקיפדיה העברית וב-[[User:${botName}|${botName}]]
 
 User: מה אתה חושב על בנימין נתניהו?
-Bot: אני מצטער, אני עונה רק על שאלות הקשורות בוויקיפדיה העברית וב-[[User:Sapper-bot|Sapper-bot]]
+Bot: אני מצטער, אני עונה רק על שאלות הקשורות בוויקיפדיה העברית וב-[[User:${botName}|${botName}]]
 
 User: האם מותר להעתיק כתבה מ-ynet לערך חדש בוויקיפדיה העברית?
 Bot: בהתאם ל-[[ויקיפדיה:זכויות יוצרים]] אסור להעתיק מכל יצירה ללא רשות בעל הזכויות. ניתן להסתמך על המידע שבכתבה לצורך יצירת ערך חדש.

--- a/bot/tag-bot/index.ts
+++ b/bot/tag-bot/index.ts
@@ -1,6 +1,6 @@
 import botLoggerDecorator from '../decorators/botLoggerDecorator';
 import { WikiNotification } from '../types';
-import { getLocalTimeAndDate } from '../utilities';
+import { escapeRegex, getLocalTimeAndDate } from '../utilities';
 import WikiApi, { IWikiApi } from '../wiki/WikiApi';
 import { getAllParagraphs, getParagraphContent, parseParagraph } from '../wiki/paragraphParser';
 import { getInnerLinks } from '../wiki/wikiLinkParser';
@@ -10,7 +10,13 @@ import { logger } from '../utilities/logger';
 import { checkExternalLinks } from './actions/checkPage';
 import { getRedirectTargetFromContent } from '../wiki/redirectParser';
 
-const TAG_PAGE_NAME = 'משתמש:Sapper-bot/בוט התיוג';
+const botName = process.env.BOT_NAME as string;
+const escapedBotName = escapeRegex(botName);
+const botMentionRegex = new RegExp(`@\\[\\[(?:(?:משתמש|user):)?${escapedBotName}(?:\\|${escapedBotName})?\\]\\]`, 'i');
+const directBotMentionRegex = new RegExp(`^@(?:(?:משתמש|user):)?${escapedBotName}`, 'i');
+const botNameRegex = new RegExp(`@?${escapedBotName}`, 'i');
+const TAG_PAGE_NAME = `משתמש:${botName}/בוט התיוג`;
+const EMAILS_PAGE_NAME = `user:${botName}/אימיילים`;
 const SUMMARY_PREFIX = `[[${TAG_PAGE_NAME}|בוט התיוג]]: `;
 
 const failedMessage = 'שגיאה לא ידועה: [[משתמש:החבלן]], שים לב ותקן.';
@@ -90,7 +96,7 @@ async function performAction(
   try {
     const pageContent = await api.articleContent(title);
     const paragraphs = getAllParagraphs(pageContent.content, title);
-    const paragraphContent = paragraphs.find((paragraph) => paragraph.match(/@\[\[(?:(?:משתמש|user):)?Sapper-bot/i)
+    const paragraphContent = paragraphs.find((paragraph) => paragraph.match(botMentionRegex)
       && paragraph.match(actionRegex)
       && paragraph.includes(user)
       && getTimeStampOptions(timestamp).some((time) => paragraph.includes(time)));
@@ -258,14 +264,14 @@ async function handleNotification(
   console.log({ title });
   const { body } = notification['*'];
   console.log({ body });
-  if (!body.trim().match(/^@(?:(?:משתמש|user):)?Sapper-bot/i)) {
+  if (!body.trim().match(directBotMentionRegex)) {
     console.log('Not for bot');
     return;
   }
   const user = notification.agent.name;
   const commentSummary = getCommentSummary(user);
   const commentPrefix = getCommentPrefix(user);
-  const withoutTag = body.replace(/@?Sapper-bot/i, '').trim();
+  const withoutTag = body.replace(botNameRegex, '').trim();
   console.log({ withoutTag });
   if (!withoutTag.includes(':')) {
     console.log('Probably it is just mention?');
@@ -301,12 +307,12 @@ async function saveNotification(api: IWikiApi, notification: WikiNotification) {
   try {
     const content = `@[[משתמש:החבלן]], שים לב: [${notification['*'].links.primary.url} ${notification['*'].links.primary.label}]. ~~~~`;
     const title = notification['*'].header;
-    const [info] = await api.info(['user:Sapper-bot/אימיילים']);
+    const [info] = await api.info([EMAILS_PAGE_NAME]);
     const revid = info?.lastrevid;
     if (!revid) {
-      throw new Error('No revid for user:Sapper-bot/אימיילים');
+      throw new Error(`No revid for ${EMAILS_PAGE_NAME}`);
     }
-    await api.edit('user:Sapper-bot/אימיילים', title, content, revid, title);
+    await api.edit(EMAILS_PAGE_NAME, title, content, revid, title);
   } catch (e) {
     logger.logError(`Failed to save notification: ${e.message || e.data || e.toString()}`);
   }

--- a/bot/usMarketValue/index.ts
+++ b/bot/usMarketValue/index.ts
@@ -97,11 +97,12 @@ export async function checkWikidata() {
     ],
   );
   const tableText = buildTable(['קישור לערך', 'מזהה מניה בוויקיפדיה', 'מזהה ויקינתונים', 'מזהה מניה בוויקינתונים'], table);
-  const info = await api.info(['user:Sapper-bot/מניות ארצות הברית']);
+  const botPage = `user:${process.env.BOT_NAME}/מניות ארצות הברית`;
+  const info = await api.info([botPage]);
   if (!info[0].lastrevid) {
     throw new Error('Failed to get revid');
   }
-  await api.edit('user:Sapper-bot/מניות ארצות הברית', 'עדכון', tableText, info[0].lastrevid);
+  await api.edit(botPage, 'עדכון', tableText, info[0].lastrevid);
 }
 
 export default async function usMarketValueBot() {

--- a/bot/utilities.ts
+++ b/bot/utilities.ts
@@ -236,7 +236,7 @@ export function convertContentToWikiPage(content: string, revid: number, title: 
           contentformat: 'text/x-wiki',
         },
       },
-      user: 'Sapper-bot',
+      user: process.env.BOT_NAME as string,
       size: content.length,
     }],
   };


### PR DESCRIPTION
## What changed

- Use `BOT_NAME` for active bot-owned log, report, configuration, and notification pages.
- Use the configured name when the tag bot recognizes and removes mentions, including archive and move commands.
- Escape the configured name before embedding it in regular expressions.
- Use the configured identity in the tag bot's GPT instructions and in synthetic revision data.
- Update affected tests to follow the configured name.

## Scope

This follows #1177 and intentionally limits the change to runtime identity. Historical corpus content, README links, one-time scripts, and legacy non-deployed scripts remain tied to `Sapper-bot`.

## Impact

Changing `WIKI_BOT_NAME` now updates the bot's operational pages and tag-command identity in addition to the API user agent and central run log.

## Validation

- Type checking passed.
- ESLint passed.
- All 800 unit tests passed with 100% coverage using `BOT_NAME=Test.bot`, which also verifies regex escaping for a name containing a special character.
- Production dependency smoke tests passed.