### PR TITLE
Improve external link verification under anti-bot blocking

### DIFF
--- a/bot/__tests__/checkPage.test.ts
+++ b/bot/__tests__/checkPage.test.ts
@@ -1,11 +1,15 @@
 import {
-  afterEach, beforeEach, describe, expect, it, jest,
+  beforeEach, describe, expect, it, jest,
 } from '@jest/globals';
+import { LinkCheckResult } from '../tag-bot/actions/externalLinkChecker';
 
 const getExternalLinksMock = jest.fn<() => Array<{ link: string; text: string }>>();
 const handlePageMock = jest.fn() as any;
 const queuePlaywrightLinkCheckMock: any = jest.fn();
-const fetchMock = jest.fn<typeof fetch>();
+const checkLinksWithHttpMock: any = jest.fn();
+const lookupIABotLinksMock: any = jest.fn();
+const logErrorMock: any = jest.fn();
+const logWarningMock: any = jest.fn();
 
 jest.unstable_mockModule('../wiki/wikiLinkParser', () => ({
   getExternalLinks: getExternalLinksMock,
@@ -19,150 +23,173 @@ jest.unstable_mockModule('../tag-bot/actions/playwrightLinkQueue', () => ({
   queuePlaywrightLinkCheck: queuePlaywrightLinkCheckMock,
 }));
 
+jest.unstable_mockModule('../tag-bot/actions/externalLinkChecker', () => ({
+  checkLinksWithHttp: checkLinksWithHttpMock,
+}));
+
+jest.unstable_mockModule('../tag-bot/actions/internetArchiveBot', () => ({
+  lookupIABotLinks: lookupIABotLinksMock,
+}));
+
+jest.unstable_mockModule('../utilities/logger', () => ({
+  logger: {
+    logError: logErrorMock,
+    logWarning: logWarningMock,
+  },
+}));
+
 const { checkCopyright, checkExternalLinks } = await import('../tag-bot/actions/checkPage');
 
-describe('checkExternalLinks', () => {
-  let consoleErrorSpy: any;
+function httpResults(entries: Array<[string, LinkCheckResult]>) {
+  checkLinksWithHttpMock.mockResolvedValue(new Map(entries));
+}
 
+describe('checkExternalLinks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
     getExternalLinksMock.mockReturnValue([
       { link: 'https://example.com/one', text: 'One' },
       { link: 'https://example.com/two', text: 'Two' },
     ]);
-    globalThis.fetch = fetchMock as typeof fetch;
-  });
-
-  afterEach(() => {
-    fetchMock.mockReset();
+    queuePlaywrightLinkCheckMock.mockResolvedValue(undefined);
+    lookupIABotLinksMock.mockResolvedValue(new Map());
   });
 
   it('should return success when all links are reachable', async () => {
-    fetchMock.mockResolvedValue({
-      status: 200,
-      statusText: 'OK',
-    } as Response);
+    httpResults([
+      ['https://example.com/one', { state: 'alive', status: 200, statusText: 'OK' }],
+      ['https://example.com/two', { state: 'alive', status: 200, statusText: 'OK' }],
+    ]);
 
-    const result = await checkExternalLinks('content');
+    const result = await checkExternalLinks('content', {
+      title: 'Page title', commentSummary: 'Summary', commentId: '1',
+    });
 
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      1,
-      'https://example.com/one',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'User-Agent': expect.any(String),
-        }),
-      }),
-    );
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      'https://example.com/two',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'User-Agent': expect.any(String),
-        }),
-      }),
-    );
+    expect(checkLinksWithHttpMock).toHaveBeenCalledWith(expect.any(Array), 'Page title');
+    expect(lookupIABotLinksMock).not.toHaveBeenCalled();
+    expect(queuePlaywrightLinkCheckMock).not.toHaveBeenCalled();
     expect(result).toBe('כל הקישורים תקינים');
   });
 
-  it('should report non-2xx responses as broken links', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        status: 200,
-        statusText: 'OK',
-      } as Response)
-      .mockResolvedValueOnce({
-        status: 403,
-        statusText: 'Forbidden',
-      } as Response);
-    queuePlaywrightLinkCheckMock.mockResolvedValue(undefined);
-
-    const result = await checkExternalLinks('content');
-
-    expect(queuePlaywrightLinkCheckMock).toHaveBeenCalledWith({
-      title: '',
-      commentSummary: '',
-      commentId: '',
-      links: [
-        { link: 'https://example.com/two', text: 'Two' },
-      ],
-    });
-    expect(result).toBe('כל הקישורים שנגישים לבוט תקינים. קישורים שחסומים לבוט נשלחו לבדיקה ברקע.');
-  });
-
-  it('should report playwright failures as broken links', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        status: 200,
-        statusText: 'OK',
-      } as Response)
-      .mockResolvedValueOnce({
-        status: 403,
-        statusText: 'Forbidden',
-      } as Response);
-    queuePlaywrightLinkCheckMock.mockRejectedValue(new Error('queue failed'));
-
-    const result = await checkExternalLinks('content');
-
-    expect(result).toBe('חלק מהקישורים חסומים לבוט ונשלחו לבדיקה ברקע. קישורים שבורים:\n* [https://example.com/two Two], לא ניתן להעביר לבדיקה ברקע - queue failed');
-  });
-
-  it('should format non-Error playwright failures as strings', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        status: 403,
-        statusText: 'Forbidden',
-      } as Response);
-    queuePlaywrightLinkCheckMock.mockRejectedValue({ reason: 'queue failed' });
-    getExternalLinksMock.mockReturnValue([
-      { link: 'https://example.com/one', text: 'One' },
+  it('should accept an alive IABot result for a blocked link', async () => {
+    httpResults([
+      ['https://example.com/one', { state: 'alive', status: 200 }],
+      ['https://example.com/two', { state: 'blocked', status: 403 }],
     ]);
-
-    const result = await checkExternalLinks('content');
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith({ reason: 'queue failed' });
-    expect(result).toBe('חלק מהקישורים חסומים לבוט ונשלחו לבדיקה ברקע. קישורים שבורים:\n* [https://example.com/one One], לא ניתן להעביר לבדיקה ברקע - [object Object]');
-  });
-
-  it('should report non-403 status codes as broken links without playwright', async () => {
-    getExternalLinksMock.mockReturnValue([
-      { link: 'https://example.com/one', text: 'One' },
-    ]);
-    fetchMock.mockResolvedValueOnce({
-      status: 500,
-      statusText: 'Internal Server Error',
-    } as Response);
+    lookupIABotLinksMock.mockResolvedValue(new Map([['https://example.com/two', 'alive']]));
 
     const result = await checkExternalLinks('content');
 
     expect(queuePlaywrightLinkCheckMock).not.toHaveBeenCalled();
-    expect(result).toBe('קישורים שבורים:\n* [https://example.com/one One], לא ניתן להגיע לקישור - 500 - Internal Server Error');
+    expect(result).toBe('כל הקישורים תקינים');
   });
 
-  it('should log request errors and include them in the report', async () => {
-    fetchMock.mockRejectedValueOnce('boom');
-    getExternalLinksMock.mockReturnValue([
-      { link: 'https://example.com/one', text: 'One' },
+  it('should report an IABot-confirmed dead link as broken', async () => {
+    httpResults([
+      ['https://example.com/one', { state: 'alive', status: 200 }],
+      ['https://example.com/two', { state: 'blocked', status: 403, statusText: 'Forbidden' }],
+    ]);
+    lookupIABotLinksMock.mockResolvedValue(new Map([['https://example.com/two', 'dead']]));
+
+    const result = await checkExternalLinks('content');
+
+    expect(result).toBe('קישורים שבורים:\n* [https://example.com/two Two], לא ניתן להגיע לקישור - 403 - Forbidden');
+  });
+
+  it('should queue blocked, transient, and unknown links for a background check', async () => {
+    httpResults([
+      ['https://example.com/one', { state: 'alive', status: 200 }],
+      ['https://example.com/two', { state: 'blocked', status: 403 }],
+    ]);
+
+    const result = await checkExternalLinks('content', {
+      title: 'Page', commentSummary: 'Summary', commentId: '1',
+    });
+
+    expect(queuePlaywrightLinkCheckMock).toHaveBeenCalledWith({
+      title: 'Page',
+      commentSummary: 'Summary',
+      commentId: '1',
+      links: [{ link: 'https://example.com/two', text: 'Two' }],
+    });
+    expect(result).toBe('כל הקישורים שניתן היה לאמת תקינים. קישורים שלא ניתן היה לאמת נשלחו לבדיקה ברקע.');
+  });
+
+  it('should keep a repeatedly missing link broken when IABot has no result', async () => {
+    getExternalLinksMock.mockReturnValue([{ link: 'https://example.com/one', text: 'One' }]);
+    httpResults([['https://example.com/one', { state: 'dead', status: 404, statusText: 'Not Found' }]]);
+
+    const result = await checkExternalLinks('content');
+
+    expect(result).toBe('קישורים שבורים:\n* [https://example.com/one One], לא ניתן להגיע לקישור - 404 - Not Found');
+  });
+
+  it('should format broken links with errors or without HTTP details', async () => {
+    httpResults([
+      ['https://example.com/one', { state: 'dead', error: 'DNS failure' }],
+      ['https://example.com/two', { state: 'dead' }],
     ]);
 
     const result = await checkExternalLinks('content');
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith('boom');
-    expect(result).toBe('קישורים שבורים:\n* [https://example.com/one One], boom');
+    expect(result).toContain('* [https://example.com/one One], DNS failure');
+    expect(result).toContain('* [https://example.com/two Two], לא ניתן לקבוע אם הקישור תקין');
   });
 
-  it('should log Error objects and include their message', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('kaboom'));
-    getExternalLinksMock.mockReturnValue([
-      { link: 'https://example.com/one', text: 'One' },
+  it('should report broken links while unresolved links continue in the background', async () => {
+    httpResults([
+      ['https://example.com/one', { state: 'dead', status: 404 }],
+      ['https://example.com/two', { state: 'blocked', status: 403 }],
     ]);
 
     const result = await checkExternalLinks('content');
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(new Error('kaboom'));
-    expect(result).toBe('קישורים שבורים:\n* [https://example.com/one One], kaboom');
+    expect(result).toContain('קישורים שלא ניתן היה לאמת נשלחו לבדיקה ברקע.');
+    expect(result).toContain('לא ניתן להגיע לקישור - 404 - ');
+  });
+
+  it('should fall back to the background check when IABot fails', async () => {
+    getExternalLinksMock.mockReturnValue([{ link: 'https://example.com/one', text: 'One' }]);
+    httpResults([['https://example.com/one', { state: 'blocked', status: 403 }]]);
+    lookupIABotLinksMock.mockRejectedValue(new Error('IABot unavailable'));
+
+    const result = await checkExternalLinks('content');
+
+    expect(logWarningMock).toHaveBeenCalledWith(new Error('IABot unavailable'));
+    expect(queuePlaywrightLinkCheckMock).toHaveBeenCalledWith(expect.any(Object));
+    expect(result).toContain('נשלחו לבדיקה ברקע');
+  });
+
+  it('should report a queue failure as unverifiable rather than broken', async () => {
+    getExternalLinksMock.mockReturnValue([{ link: 'https://example.com/one', text: 'One' }]);
+    httpResults([['https://example.com/one', { state: 'transient', error: 'timeout' }]]);
+    queuePlaywrightLinkCheckMock.mockRejectedValue(new Error('queue failed'));
+
+    const result = await checkExternalLinks('content');
+
+    expect(logErrorMock).toHaveBeenCalledWith(new Error('queue failed'));
+    expect(result).toBe('קישורים שלא ניתן היה לאמת:\n* [https://example.com/one One], לא ניתן להעביר לבדיקה ברקע - queue failed');
+    expect(result).not.toContain('קישורים שבורים');
+  });
+
+  it('should format non-Error queue failures', async () => {
+    getExternalLinksMock.mockReturnValue([{ link: 'https://example.com/one', text: 'One' }]);
+    httpResults([['https://example.com/one', { state: 'transient' }]]);
+    queuePlaywrightLinkCheckMock.mockRejectedValue('queue unavailable');
+
+    const result = await checkExternalLinks('content');
+
+    expect(result).toContain('לא ניתן להעביר לבדיקה ברקע - queue unavailable');
+  });
+
+  it('should handle a missing HTTP result as unverifiable', async () => {
+    getExternalLinksMock.mockReturnValue([{ link: 'https://example.com/one', text: 'One' }]);
+    checkLinksWithHttpMock.mockResolvedValue(new Map());
+
+    const result = await checkExternalLinks('content');
+
+    expect(queuePlaywrightLinkCheckMock).toHaveBeenCalledWith(expect.any(Object));
+    expect(result).toContain('נשלחו לבדיקה ברקע');
   });
 });
 

--- a/bot/__tests__/externalLinkChecker.test.ts
+++ b/bot/__tests__/externalLinkChecker.test.ts
@@ -200,7 +200,8 @@ describe('externalLinkChecker', () => {
     await expect(checkLinksWithHttp([])).resolves.toStrictEqual(new Map());
   });
 
-  it('should use the default Wikipedia base URL for referrers', async () => {
+  it('should use the default bot name and Wikipedia base URL', async () => {
+    delete process.env.BOT_NAME;
     delete process.env.BASE_URL;
     fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
 
@@ -209,7 +210,10 @@ describe('externalLinkChecker', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-      headers: expect.objectContaining({ Referer: 'https://he.wikipedia.org/wiki/Page' }),
+      headers: expect.objectContaining({
+        'User-Agent': 'Sapper-bot/1.0 (https://he.wikipedia.org/wiki/User:Sapper-bot)',
+        Referer: 'https://he.wikipedia.org/wiki/Page',
+      }),
     }));
   });
 

--- a/bot/__tests__/externalLinkChecker.test.ts
+++ b/bot/__tests__/externalLinkChecker.test.ts
@@ -1,0 +1,230 @@
+import {
+  beforeEach, describe, expect, it, jest,
+} from '@jest/globals';
+import {
+  checkLinksWithHttp, classifyLinkStatus, clearLinkCheckCache, getExternalLinkUserAgent,
+} from '../tag-bot/actions/externalLinkChecker';
+
+const links = [{ link: 'https://example.com/page', text: 'Page' }];
+
+describe('externalLinkChecker', () => {
+  const fetchMock = jest.fn<typeof fetch>();
+  const sleepMock = jest.fn<(milliseconds: number) => Promise<void>>();
+  let now: number;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearLinkCheckCache();
+    now = Date.now();
+    sleepMock.mockResolvedValue(undefined);
+    process.env.BOT_NAME = 'Sapper-bot';
+    process.env.BASE_URL = 'https://he.wikipedia.org';
+  });
+
+  it('should send an honest bot user agent and Wikipedia referrer', async () => {
+    fetchMock.mockResolvedValue(new Response('OK', { status: 200 }));
+
+    const result = await checkLinksWithHttp(links, 'ערך לדוגמה', {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/page', expect.objectContaining({
+      redirect: 'follow',
+      headers: expect.objectContaining({
+        'User-Agent': 'Sapper-bot/1.0 (https://he.wikipedia.org/wiki/User:Sapper-bot)',
+        Referer: 'https://he.wikipedia.org/wiki/%D7%A2%D7%A8%D7%9A_%D7%9C%D7%93%D7%95%D7%92%D7%9E%D7%94',
+        Accept: expect.any(String),
+        'Accept-Language': expect.any(String),
+      }),
+    }));
+    expect(result.get(links[0].link)?.state).toBe('alive');
+    expect(getExternalLinkUserAgent()).toContain('Sapper-bot/1.0');
+  });
+
+  it('should retry and confirm 404 responses', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 404, statusText: 'Not Found' }));
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledWith(expect.any(Number));
+    expect(result.get(links[0].link)).toStrictEqual(expect.objectContaining({
+      state: 'dead', status: 404, statusText: 'Not Found',
+    }));
+  });
+
+  it('should honor numeric, invalid, and dated Retry-After values', async () => {
+    const dateNow = Date.now();
+    const dateNowMock = jest.spyOn(Date, 'now').mockReturnValue(dateNow);
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 404, headers: { 'Retry-After': '2' } }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404, headers: { 'Retry-After': 'invalid' } }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, {
+        status: 404,
+        headers: { 'Retry-After': new Date(dateNow + 3000).toISOString() },
+      }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await checkLinksWithHttp([
+      { link: 'https://one.example/page', text: 'One' },
+      { link: 'https://two.example/page', text: 'Two' },
+      { link: 'https://three.example/page', text: 'Three' },
+    ], undefined, { fetchFn: fetchMock, sleep: sleepMock, now: () => now });
+
+    dateNowMock.mockRestore();
+
+    expect(sleepMock).toHaveBeenCalledWith(2000);
+    expect(sleepMock).toHaveBeenCalledWith(1000);
+    expect(sleepMock).toHaveBeenCalledWith(3000);
+  });
+
+  it('should classify 403 as blocked without retrying', async () => {
+    fetchMock.mockResolvedValue(new Response('Forbidden', { status: 403, statusText: 'Forbidden' }));
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.get(links[0].link)?.state).toBe('blocked');
+  });
+
+  it('should identify a Cloudflare challenge returned as 503', async () => {
+    fetchMock.mockResolvedValue(new Response('<title>Just a moment...</title>', {
+      status: 503,
+      headers: { server: 'cloudflare' },
+    }));
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.get(links[0].link)?.state).toBe('blocked');
+  });
+
+  it('should detect challenge headers and Cloudflare 403 responses', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 503, headers: { 'cf-mitigated': 'challenge' } }))
+      .mockResolvedValueOnce(new Response('', { status: 403, headers: { server: 'cloudflare' } }));
+
+    const result = await checkLinksWithHttp([
+      { link: 'https://one.example/page', text: 'One' },
+      { link: 'https://two.example/page', text: 'Two' },
+    ], undefined, { fetchFn: fetchMock, sleep: sleepMock, now: () => now });
+
+    expect(result.get('https://one.example/page')?.state).toBe('blocked');
+    expect(result.get('https://two.example/page')?.state).toBe('blocked');
+  });
+
+  it('should handle challenge responses without a body', async () => {
+    const response = {
+      status: 403,
+      statusText: 'Forbidden',
+      headers: new Headers(),
+      body: null,
+    } as Response;
+    fetchMock.mockResolvedValue(response);
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock, sleep: sleepMock, now: () => now,
+    });
+
+    expect(result.get(links[0].link)?.state).toBe('blocked');
+  });
+
+  it('should retry transient request errors and preserve the final error', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.get(links[0].link)).toStrictEqual({ state: 'transient', error: 'timeout' });
+  });
+
+  it('should preserve non-Error request failures', async () => {
+    fetchMock.mockRejectedValue('network unavailable');
+
+    const result = await checkLinksWithHttp(links, undefined, {
+      fetchFn: fetchMock, sleep: sleepMock, now: () => now,
+    });
+
+    expect(result.get(links[0].link)).toStrictEqual({ state: 'transient', error: 'network unavailable' });
+  });
+
+  it('should classify uncommon response statuses', () => {
+    expect(classifyLinkStatus(410)).toBe('dead');
+    expect(classifyLinkStatus(401)).toBe('blocked');
+    expect(classifyLinkStatus(408)).toBe('transient');
+    expect(classifyLinkStatus(418)).toBe('unknown');
+  });
+
+  it('should reuse cached URL results', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const dependencies = { fetchFn: fetchMock, sleep: sleepMock, now: () => now };
+
+    await checkLinksWithHttp(links, undefined, dependencies);
+    await checkLinksWithHttp(links, undefined, dependencies);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refresh expired cached results', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const dependencies = { fetchFn: fetchMock, sleep: sleepMock, now: () => now };
+
+    await checkLinksWithHttp(links, undefined, dependencies);
+    now += 11 * 60 * 1000;
+    await checkLinksWithHttp(links, undefined, dependencies);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should support an empty check with default dependencies', async () => {
+    await expect(checkLinksWithHttp([])).resolves.toStrictEqual(new Map());
+  });
+
+  it('should use the default Wikipedia base URL for referrers', async () => {
+    delete process.env.BASE_URL;
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await checkLinksWithHttp(links, 'Page', {
+      fetchFn: fetchMock, sleep: sleepMock, now: () => now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      headers: expect.objectContaining({ Referer: 'https://he.wikipedia.org/wiki/Page' }),
+    }));
+  });
+
+  it('should pace different URLs on the same host', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+
+    await checkLinksWithHttp([
+      ...links,
+      { link: 'https://example.com/other', text: 'Other' },
+    ], undefined, {
+      fetchFn: fetchMock,
+      sleep: sleepMock,
+      now: () => now,
+    });
+
+    expect(sleepMock).toHaveBeenCalledWith(1000);
+  });
+});

--- a/bot/__tests__/internetArchiveBot.test.ts
+++ b/bot/__tests__/internetArchiveBot.test.ts
@@ -1,0 +1,191 @@
+import {
+  beforeEach, describe, expect, it, jest,
+} from '@jest/globals';
+import { clearIABotCache, lookupIABotLinks } from '../tag-bot/actions/internetArchiveBot';
+
+describe('internetArchiveBot', () => {
+  const fetchMock = jest.fn<typeof fetch>();
+  let now: number;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearIABotCache();
+    now = Date.parse('2026-07-19T00:00:00Z');
+  });
+
+  it('should batch URLs and map fresh IABot states', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: {
+        1: {
+          url: 'https://example.com/alive',
+          accesstime: '2026-07-18 12:00:00',
+          live_state: 'alive',
+        },
+        2: {
+          url: 'https://example.com/dead',
+          accesstime: '2026-07-17 12:00:00',
+          live_state: 'dead',
+        },
+      },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks([
+      'https://example.com/alive',
+      'https://example.com/dead',
+    ], { fetchFn: fetchMock, now: () => now });
+
+    expect(result.get('https://example.com/alive')).toBe('alive');
+    expect(result.get('https://example.com/dead')).toBe('dead');
+
+    const request = fetchMock.mock.calls[0][1];
+
+    expect(request?.method).toBe('POST');
+    expect((request?.body as URLSearchParams).get('urls')).toBe('https://example.com/alive\nhttps://example.com/dead');
+  });
+
+  it('should trust permanent domain states without a recent access time', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: {
+        1: { normalizedurl: 'https://example.com/', live_state: 'whitelisted' },
+      },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks(['https://example.com'], {
+      fetchFn: fetchMock, now: () => now,
+    });
+
+    expect(result.get('https://example.com')).toBe('alive');
+  });
+
+  it('should ignore stale non-permanent results', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: {
+        1: {
+          url: 'https://example.com',
+          accesstime: '2025-01-01 00:00:00',
+          live_state: 'alive',
+        },
+      },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks(['https://example.com'], {
+      fetchFn: fetchMock, now: () => now,
+    });
+
+    expect(result.get('https://example.com')).toBe('unknown');
+  });
+
+  it('should map fresh non-final IABot states', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: {
+        1: { url: 'https://example.com/dying', accesstime: '2026-07-18 12:00:00', live_state: 'dying' },
+        2: { url: 'https://example.com/paywall', accesstime: '2026-07-18 12:00:00', live_state: 'paywall' },
+        3: { url: 'https://example.com/other', accesstime: '2026-07-18 12:00:00', live_state: 'other' },
+      },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks([
+      'https://example.com/dying',
+      'https://example.com/paywall',
+      'https://example.com/other',
+    ], { fetchFn: fetchMock, now: () => now });
+
+    expect(result.get('https://example.com/dying')).toBe('transient');
+    expect(result.get('https://example.com/paywall')).toBe('blocked');
+    expect(result.get('https://example.com/other')).toBe('unknown');
+  });
+
+  it('should ignore records without access times or with invalid access times', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: {
+        1: { url: 'https://example.com/missing', live_state: 'alive' },
+        2: { url: 'https://example.com/invalid', accesstime: 'not-a-date', live_state: 'alive' },
+      },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks([
+      'https://example.com/missing',
+      'https://example.com/invalid',
+    ], { fetchFn: fetchMock, now: () => now });
+
+    expect(result.get('https://example.com/missing')).toBe('unknown');
+    expect(result.get('https://example.com/invalid')).toBe('unknown');
+  });
+
+  it('should map blacklisted domains as dead', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: { 1: { url: 'https://example.com', live_state: 'blacklisted' } },
+    }), { status: 200 }));
+
+    const result = await lookupIABotLinks(['https://example.com'], {
+      fetchFn: fetchMock, now: () => now,
+    });
+
+    expect(result.get('https://example.com')).toBe('dead');
+  });
+
+  it('should return unknown for URLs IABot has not encountered', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ urls: {} }), { status: 200 }));
+
+    const result = await lookupIABotLinks(['https://unknown.example'], {
+      fetchFn: fetchMock, now: () => now,
+    });
+
+    expect(result.get('https://unknown.example')).toBe('unknown');
+  });
+
+  it('should handle invalid URLs and responses without a urls property', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+    const result = await lookupIABotLinks(['not a URL'], {
+      fetchFn: fetchMock, now: () => now,
+    });
+
+    expect(result.get('not a URL')).toBe('unknown');
+  });
+
+  it('should reuse cached results', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      urls: { 1: { url: 'https://example.com', live_state: 'whitelisted' } },
+    }), { status: 200 }));
+    const dependencies = { fetchFn: fetchMock, now: () => now };
+
+    await lookupIABotLinks(['https://example.com'], dependencies);
+    await lookupIABotLinks(['https://example.com/'], dependencies);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refresh expired cached results', async () => {
+    fetchMock.mockImplementation(async () => new Response(JSON.stringify({
+      urls: { 1: { url: 'https://example.com', live_state: 'whitelisted' } },
+    }), { status: 200 }));
+    const dependencies = { fetchFn: fetchMock, now: () => now };
+
+    await lookupIABotLinks(['https://example.com'], dependencies);
+    now += 2 * 60 * 60 * 1000;
+    await lookupIABotLinks(['https://example.com'], dependencies);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should support an empty lookup with default dependencies', async () => {
+    await expect(lookupIABotLinks([])).resolves.toStrictEqual(new Map());
+  });
+
+  it('should throw when IABot returns an error response', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 429, statusText: 'Too Many Requests' }));
+
+    await expect(lookupIABotLinks(['https://example.com'], {
+      fetchFn: fetchMock, now: () => now,
+    })).rejects.toThrow('IABot returned 429 Too Many Requests');
+  });
+
+  it('should cancel error response bodies before throwing', async () => {
+    fetchMock.mockResolvedValue(new Response('rate limited', { status: 429, statusText: 'Too Many Requests' }));
+
+    await expect(lookupIABotLinks(['https://example.com'], {
+      fetchFn: fetchMock, now: () => now,
+    })).rejects.toThrow('IABot returned 429 Too Many Requests');
+  });
+});

--- a/bot/__tests__/tagBotPlaywrightCheck.test.ts
+++ b/bot/__tests__/tagBotPlaywrightCheck.test.ts
@@ -3,34 +3,27 @@ import {
 } from '@jest/globals';
 
 const closeMock: any = jest.fn();
-closeMock.mockResolvedValue(undefined);
 const gotoMock: any = jest.fn();
+const reloadMock: any = jest.fn();
+const waitForTimeoutMock: any = jest.fn();
 const titleMock: any = jest.fn();
-titleMock.mockResolvedValue('Example');
+const contentMock: any = jest.fn();
 const pageMock = {
   goto: gotoMock,
+  reload: reloadMock,
+  waitForTimeout: waitForTimeoutMock,
   close: closeMock,
   title: titleMock,
+  content: contentMock,
 };
 const newPageMock: any = jest.fn();
-newPageMock.mockResolvedValue(pageMock);
 const browserCloseMock: any = jest.fn();
-browserCloseMock.mockResolvedValue(undefined);
 const contextCloseMock: any = jest.fn();
-contextCloseMock.mockResolvedValue(undefined);
 const newContextMock: any = jest.fn();
-newContextMock.mockResolvedValue({
-  newPage: newPageMock,
-  close: contextCloseMock,
-});
 const launchMock: any = jest.fn();
-launchMock.mockResolvedValue({
-  newContext: newContextMock,
-  close: browserCloseMock,
-});
 const logErrorMock: any = jest.fn();
-const wikiLoginMock: any = jest.fn(() => Promise.resolve(undefined));
-const wikiAddCommentMock: any = jest.fn(() => Promise.resolve(undefined));
+const wikiLoginMock: any = jest.fn();
+const wikiAddCommentMock: any = jest.fn();
 const wikiApiMock: any = jest.fn(() => ({
   login: wikiLoginMock,
   addComment: wikiAddCommentMock,
@@ -56,36 +49,63 @@ jest.unstable_mockModule('../decorators/botLoggerDecorator', () => ({
   default: (cb: any) => cb,
 }));
 
-const { handleEvent, handleQueueMessage, main } = await import('../tag-bot/playwrightCheck/index');
+const {
+  handleEvent, handleQueueMessage, main, runLinkChecks,
+} = await import('../tag-bot/playwrightCheck/index');
+
+function response(status: number, statusText = '') {
+  return {
+    status: () => status,
+    statusText: () => statusText,
+  };
+}
+
+function queueBody(links: { link: string; text: string }[]) {
+  return JSON.stringify({
+    title: 'Page',
+    commentSummary: 'Summary',
+    commentId: '1',
+    links,
+  });
+}
 
 describe('tagBotPlaywrightCheck', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    wikiLoginMock.mockReset();
+    closeMock.mockResolvedValue(undefined);
+    reloadMock.mockResolvedValue(response(200, 'OK'));
+    waitForTimeoutMock.mockResolvedValue(undefined);
+    titleMock.mockResolvedValue('Example');
+    contentMock.mockResolvedValue('<html></html>');
+    newPageMock.mockResolvedValue(pageMock);
+    browserCloseMock.mockResolvedValue(undefined);
+    contextCloseMock.mockResolvedValue(undefined);
+    newContextMock.mockResolvedValue({
+      newPage: newPageMock,
+      close: contextCloseMock,
+    });
+    launchMock.mockResolvedValue({
+      newContext: newContextMock,
+      close: browserCloseMock,
+    });
     wikiLoginMock.mockResolvedValue(undefined);
-    wikiAddCommentMock.mockReset();
     wikiAddCommentMock.mockResolvedValue(undefined);
   });
 
-  it('should process SQS records and post a follow-up comment', async () => {
-    gotoMock.mockResolvedValueOnce({
-      ok: () => true,
-      status: () => 200,
-      statusText: () => 'OK',
-    });
+  it('should process SQS records and post a success comment', async () => {
+    gotoMock.mockResolvedValueOnce(response(200, 'OK'));
 
-    await main({
-      Records: [{
-        body: JSON.stringify({
-          title: 'Page',
-          commentSummary: 'Summary',
-          commentId: '1',
-          links: [{ link: 'https://example.com/one', text: 'One' }],
-        }),
-      }],
-    });
+    await main({ Records: [{ body: queueBody([{ link: 'https://example.com/one', text: 'One' }]) }] });
 
     expect(wikiApiMock).toHaveBeenCalledWith();
+    expect(newContextMock).toHaveBeenCalledWith(expect.objectContaining({
+      locale: 'he-IL',
+      timezoneId: 'Asia/Jerusalem',
+      extraHTTPHeaders: expect.objectContaining({
+        'Accept-Language': expect.any(String),
+      }),
+    }));
+    expect(newContextMock.mock.calls[0][0]).not.toHaveProperty('userAgent');
     expect(wikiAddCommentMock).toHaveBeenCalledWith(
       'Page',
       'Summary',
@@ -94,7 +114,7 @@ describe('tagBotPlaywrightCheck', () => {
     );
   });
 
-  it('should process queue messages without links', async () => {
+  it('should return immediately without launching a browser when there are no links', async () => {
     await handleQueueMessage({
       addComment: wikiAddCommentMock,
     } as ReturnType<typeof wikiApiMock>, JSON.stringify({
@@ -103,9 +123,7 @@ describe('tagBotPlaywrightCheck', () => {
       commentId: '1',
     }));
 
-    expect(launchMock).toHaveBeenCalledWith(expect.objectContaining({
-      headless: true,
-    }));
+    expect(launchMock).not.toHaveBeenCalled();
     expect(wikiAddCommentMock).toHaveBeenCalledWith(
       'Page',
       'Summary',
@@ -114,41 +132,77 @@ describe('tagBotPlaywrightCheck', () => {
     );
   });
 
-  it('should post a failure comment for blocked links in queue messages', async () => {
-    gotoMock.mockResolvedValueOnce({
-      ok: () => false,
-      status: () => 403,
-      statusText: () => 'Forbidden',
-    });
+  it('should accept a link when a challenge retry succeeds', async () => {
+    gotoMock.mockResolvedValueOnce(response(403, 'Forbidden'));
+    reloadMock.mockResolvedValueOnce(response(200, 'OK'));
 
-    await handleQueueMessage({
-      addComment: wikiAddCommentMock,
-    } as ReturnType<typeof wikiApiMock>, JSON.stringify({
-      title: 'Page',
-      commentSummary: 'Summary',
-      commentId: '1',
-      links: [{ link: 'https://example.com/one', text: 'One' }],
-    }));
+    const result = await runLinkChecks([{ link: 'https://example.com/one', text: 'One' }]);
 
-    expect(wikiAddCommentMock).toHaveBeenCalledWith(
-      'Page',
-      'Summary',
-      expect.stringContaining('קישורים שנכשלו בבדיקה ברקע'),
-      '1',
-    );
+    expect(waitForTimeoutMock).toHaveBeenCalledWith(5000);
+    expect(reloadMock).toHaveBeenCalledWith(expect.objectContaining({ waitUntil: 'domcontentloaded' }));
+    expect(result.results[0]).toStrictEqual(expect.objectContaining({ state: 'alive', ok: true, status: 200 }));
   });
 
-  it('should handle string navigation failures in queue messages', async () => {
-    gotoMock.mockRejectedValueOnce('blocked');
+  it('should report blocked and dead links in separate sections', async () => {
+    gotoMock
+      .mockResolvedValueOnce(response(403, 'Forbidden'))
+      .mockResolvedValueOnce(response(404, 'Not Found'));
+    reloadMock.mockResolvedValueOnce(response(403, 'Forbidden'));
 
     await handleQueueMessage({
       addComment: wikiAddCommentMock,
-    } as ReturnType<typeof wikiApiMock>, JSON.stringify({
-      title: 'Page',
-      commentSummary: 'Summary',
-      commentId: '1',
-      links: [{ link: 'https://example.com/one', text: 'One' }],
-    }));
+    } as ReturnType<typeof wikiApiMock>, queueBody([
+      { link: 'https://example.com/blocked', text: 'Blocked' },
+      { link: 'https://example.com/dead', text: 'Dead' },
+    ]));
+
+    const comment = wikiAddCommentMock.mock.calls[0][2];
+
+    expect(comment).toContain('קישורים שבורים בבדיקה ברקע');
+    expect(comment).toContain('קישורים שלא ניתן היה לאמת בבדיקה ברקע');
+    expect(comment).toContain('לא ניתן לאמת את הקישור - 403 - Forbidden');
+    expect(comment).toContain('לא ניתן להגיע לקישור - 404 - Not Found');
+  });
+
+  it('should classify a challenge page behind a 503 response as blocked', async () => {
+    gotoMock.mockResolvedValueOnce(response(503, 'Unavailable'));
+    reloadMock.mockResolvedValueOnce(response(503, 'Unavailable'));
+    titleMock.mockResolvedValueOnce('Just a moment');
+
+    const result = await runLinkChecks([{ link: 'https://example.com/one', text: 'One' }]);
+
+    expect(result.results[0]).toStrictEqual(expect.objectContaining({ state: 'blocked', ok: false }));
+  });
+
+  it('should retain the initial response when challenge reload fails', async () => {
+    gotoMock.mockResolvedValueOnce(response(503, 'Unavailable'));
+    reloadMock.mockRejectedValueOnce(new Error('reload failed'));
+
+    const result = await runLinkChecks([{ link: 'https://example.com/one', text: 'One' }]);
+
+    expect(result.results[0]).toStrictEqual(expect.objectContaining({ state: 'transient', status: 503 }));
+  });
+
+  it('should retain the initial response when challenge reload has no response', async () => {
+    gotoMock.mockResolvedValueOnce(response(429, 'Too Many Requests'));
+    reloadMock.mockResolvedValueOnce(undefined);
+    titleMock.mockRejectedValueOnce(new Error('missing title'));
+    contentMock.mockRejectedValueOnce(new Error('missing content'));
+
+    const result = await runLinkChecks([{ link: 'https://example.com/one', text: 'One' }]);
+
+    expect(result.results[0]).toStrictEqual(expect.objectContaining({ state: 'blocked', status: 429 }));
+  });
+
+  it.each([
+    ['string', 'blocked'],
+    ['Error', new Error('blocked')],
+  ])('should report %s navigation failures as unresolved', async (_label, failure) => {
+    gotoMock.mockRejectedValueOnce(failure);
+
+    await handleQueueMessage({
+      addComment: wikiAddCommentMock,
+    } as ReturnType<typeof wikiApiMock>, queueBody([{ link: 'https://example.com/one', text: 'One' }]));
 
     expect(wikiAddCommentMock).toHaveBeenCalledWith(
       'Page',
@@ -158,68 +212,26 @@ describe('tagBotPlaywrightCheck', () => {
     );
   });
 
-  it('should handle Error navigation failures in queue messages', async () => {
-    gotoMock.mockRejectedValueOnce(new Error('blocked'));
-
-    await handleQueueMessage({
-      addComment: wikiAddCommentMock,
-    } as ReturnType<typeof wikiApiMock>, JSON.stringify({
-      title: 'Page',
-      commentSummary: 'Summary',
-      commentId: '1',
-      links: [{ link: 'https://example.com/one', text: 'One' }],
-    }));
-
-    expect(wikiAddCommentMock).toHaveBeenCalledWith(
-      'Page',
-      'Summary',
-      expect.stringContaining('blocked'),
-      '1',
-    );
-  });
-
-  it('should handle missing navigation responses in queue messages', async () => {
+  it('should classify missing navigation responses as unknown', async () => {
     gotoMock.mockResolvedValueOnce(undefined);
 
-    await handleQueueMessage({
-      addComment: wikiAddCommentMock,
-    } as ReturnType<typeof wikiApiMock>, JSON.stringify({
-      title: 'Page',
-      commentSummary: 'Summary',
-      commentId: '1',
-      links: [{ link: 'https://example.com/one', text: 'One' }],
-    }));
+    const result = await runLinkChecks([{ link: 'https://example.com/one', text: 'One' }]);
 
-    expect(wikiAddCommentMock).toHaveBeenCalledWith(
-      'Page',
-      'Summary',
-      expect.stringContaining('לא ניתן להגיע לקישור - 0 - '),
-      '1',
-    );
+    expect(result.results[0]).toStrictEqual(expect.objectContaining({
+      state: 'unknown', ok: false, status: 0, statusText: '',
+    }));
   });
 
   it('should ignore SQS records without body', async () => {
-    await main({
-      Records: [{}],
-    });
+    await main({ Records: [{}] });
 
     expect(wikiAddCommentMock).not.toHaveBeenCalled();
   });
 
   it('should skip posting when comment metadata is missing', async () => {
-    gotoMock.mockResolvedValueOnce({
-      ok: () => true,
-      status: () => 200,
-      statusText: () => 'OK',
-    });
+    gotoMock.mockResolvedValueOnce(response(200, 'OK'));
 
-    await main({
-      Records: [{
-        body: JSON.stringify({
-          links: [{ link: 'https://example.com/one', text: 'One' }],
-        }),
-      }],
-    });
+    await main({ Records: [{ body: JSON.stringify({ links: [{ link: 'https://example.com', text: 'One' }] }) }] });
 
     expect(wikiAddCommentMock).not.toHaveBeenCalled();
   });

--- a/bot/tag-bot/actions/checkPage.ts
+++ b/bot/tag-bot/actions/checkPage.ts
@@ -1,8 +1,21 @@
 import { handlePage } from '../../maintenance/copyrightViolationCore';
+import { logger } from '../../utilities/logger';
 import { getExternalLinks, WikiLink } from '../../wiki/wikiLinkParser';
+import { checkLinksWithHttp, LinkCheckResult, LinkCheckState } from './externalLinkChecker';
+import { lookupIABotLinks } from './internetArchiveBot';
 import { queuePlaywrightLinkCheck } from './playwrightLinkQueue';
 
 type CheckedLink = WikiLink & { error: string };
+
+function formatCheckError(result: LinkCheckResult): string {
+  if (result.error) {
+    return result.error;
+  }
+  if (result.status) {
+    return `לא ניתן להגיע לקישור - ${result.status} - ${result.statusText ?? ''}`;
+  }
+  return 'לא ניתן לקבוע אם הקישור תקין';
+}
 
 export async function checkExternalLinks(
   content: string,
@@ -12,61 +25,73 @@ export async function checkExternalLinks(
     commentId: string;
   },
 ) {
-  const brokenLinks: CheckedLink[] = [];
-  const blockedLinks: WikiLink[] = [];
   const links = getExternalLinks(content);
-
-  for (const link of links) {
+  const httpResults = await checkLinksWithHttp(links, queueContext?.title);
+  const unresolvedLinks = links.filter((link) => httpResults.get(link.link)?.state !== 'alive');
+  let iabotResults = new Map<string, LinkCheckState>();
+  if (unresolvedLinks.length > 0) {
     try {
-      const res = await fetch(link.link, {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36',
-        },
-      });
-      if (res.status === 403) {
-        blockedLinks.push(link);
-      } else if (res.status >= 400) {
-        brokenLinks.push({
-          ...link,
-          error: `לא ניתן להגיע לקישור - ${res.status} - ${res.statusText}`,
-        });
-      }
+      iabotResults = await lookupIABotLinks(unresolvedLinks.map((link) => link.link));
     } catch (error) {
-      console.error(error);
-      brokenLinks.push({
-        ...link,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.logWarning(error);
     }
   }
-
-  if (blockedLinks.length > 0) {
+  const finalResults = links.map((link) => {
+    const httpResult = httpResults.get(link.link) ?? { state: 'unknown' } satisfies LinkCheckResult;
+    const iabotState = iabotResults.get(link.link);
+    const state = iabotState === 'alive' || iabotState === 'dead' ? iabotState : httpResult.state;
+    return { link, result: { ...httpResult, state } };
+  });
+  const brokenLinks: CheckedLink[] = finalResults
+    .filter(({ result }) => result.state === 'dead')
+    .map(({ link, result }) => ({ ...link, error: formatCheckError(result) }));
+  const linksForBackgroundCheck = finalResults
+    .filter(({ result }) => !['alive', 'dead'].includes(result.state))
+    .map(({ link }) => link);
+  const unverifiedLinks: CheckedLink[] = [];
+  let queuedLinksCount = 0;
+  if (linksForBackgroundCheck.length > 0) {
     try {
       await queuePlaywrightLinkCheck({
         title: queueContext?.title ?? '',
         commentSummary: queueContext?.commentSummary ?? '',
         commentId: queueContext?.commentId ?? '',
-        links: blockedLinks,
+        links: linksForBackgroundCheck,
       });
+      queuedLinksCount = linksForBackgroundCheck.length;
     } catch (error) {
-      console.error(error);
-      blockedLinks.forEach((link) => {
-        brokenLinks.push({
+      logger.logError(error);
+      linksForBackgroundCheck.forEach((link) => {
+        unverifiedLinks.push({
           ...link,
           error: `לא ניתן להעביר לבדיקה ברקע - ${error instanceof Error ? error.message : String(error)}`,
         });
       });
     }
   }
-  console.log({ blockedLinks });
-
-  if (!brokenLinks.length) {
-    return blockedLinks.length > 0
-      ? 'כל הקישורים שנגישים לבוט תקינים. קישורים שחסומים לבוט נשלחו לבדיקה ברקע.'
-      : 'כל הקישורים תקינים';
+  console.log({
+    externalLinkCheck: {
+      total: links.length,
+      broken: brokenLinks.length,
+      queued: queuedLinksCount,
+      unverified: unverifiedLinks.length,
+    },
+  });
+  const messages: string[] = [];
+  if (brokenLinks.length === 0 && unverifiedLinks.length === 0) {
+    messages.push(queuedLinksCount > 0
+      ? 'כל הקישורים שניתן היה לאמת תקינים. קישורים שלא ניתן היה לאמת נשלחו לבדיקה ברקע.'
+      : 'כל הקישורים תקינים');
+  } else if (queuedLinksCount > 0) {
+    messages.push('קישורים שלא ניתן היה לאמת נשלחו לבדיקה ברקע.');
   }
-  const blockedMessage = blockedLinks.length > 0 ? 'חלק מהקישורים חסומים לבוט ונשלחו לבדיקה ברקע. ' : '';
-  return `${blockedMessage}קישורים שבורים:\n${brokenLinks.map((brokenLink) => `* [${brokenLink.link} ${brokenLink.text}], ${brokenLink.error}`).join('\n')}`;
+  if (brokenLinks.length > 0) {
+    messages.push(`קישורים שבורים:\n${brokenLinks.map((link) => `* [${link.link} ${link.text}], ${link.error}`).join('\n')}`);
+  }
+  if (unverifiedLinks.length > 0) {
+    messages.push(`קישורים שלא ניתן היה לאמת:\n${unverifiedLinks.map((link) => `* [${link.link} ${link.text}], ${link.error}`).join('\n')}`);
+  }
+  return messages.join('\n');
 }
 
 export async function checkCopyright(title: string) {

--- a/bot/tag-bot/actions/externalLinkChecker.ts
+++ b/bot/tag-bot/actions/externalLinkChecker.ts
@@ -1,0 +1,218 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { WikiLink } from '../../wiki/wikiLinkParser';
+
+export type LinkCheckState = 'alive' | 'dead' | 'blocked' | 'transient' | 'unknown';
+
+export type LinkCheckResult = {
+  state: LinkCheckState;
+  status?: number;
+  statusText?: string;
+  error?: string;
+};
+
+type LinkCheckerDependencies = {
+  fetchFn: typeof fetch;
+  sleep: (milliseconds: number) => Promise<void>;
+  now: () => number;
+};
+
+const HOST_INTERVAL_MS = 1000;
+const RETRY_DELAY_MS = 1000;
+const REQUEST_TIMEOUT_MS = 15 * 1000;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const TRANSIENT_CACHE_TTL_MS = 60 * 1000;
+const MAX_RESPONSE_SAMPLE_BYTES = 32 * 1024;
+
+const resultCache = new Map<string, { result: LinkCheckResult; expiresAt: number }>();
+const hostNextRequestAt = new Map<string, number>();
+
+const defaultDependencies: LinkCheckerDependencies = {
+  fetchFn: fetch,
+  sleep,
+  now: Date.now,
+};
+
+export function getExternalLinkUserAgent(): string {
+  const botName = process.env.BOT_NAME ?? 'Sapper-bot';
+  const wikiBaseUrl = (process.env.BASE_URL ?? 'https://he.wikipedia.org').replace(/\/$/, '');
+  return `${botName}/1.0 (${wikiBaseUrl}/wiki/User:${botName})`;
+}
+
+function getReferrer(pageTitle?: string): string | undefined {
+  if (!pageTitle) {
+    return undefined;
+  }
+  const wikiBaseUrl = (process.env.BASE_URL ?? 'https://he.wikipedia.org').replace(/\/$/, '');
+  return `${wikiBaseUrl}/wiki/${encodeURIComponent(pageTitle.replace(/ /g, '_'))}`;
+}
+
+export function classifyLinkStatus(status: number): LinkCheckState {
+  if (status >= 200 && status < 400) {
+    return 'alive';
+  }
+  if (status === 404 || status === 410) {
+    return 'dead';
+  }
+  if ([401, 403, 407, 429, 451].includes(status)) {
+    return 'blocked';
+  }
+  if ([408, 425].includes(status) || status >= 500) {
+    return 'transient';
+  }
+  return 'unknown';
+}
+
+async function readResponseSample(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return '';
+  }
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    while (received < MAX_RESPONSE_SAMPLE_BYTES) {
+      const { done, value } = await reader.read();
+      if (done || !value) {
+        break;
+      }
+      const remaining = MAX_RESPONSE_SAMPLE_BYTES - received;
+      chunks.push(value.subarray(0, remaining));
+      received += Math.min(value.length, remaining);
+    }
+  } finally {
+    await Promise.allSettled([reader.cancel()]);
+  }
+  const sample = new Uint8Array(received);
+  let offset = 0;
+  chunks.forEach((chunk) => {
+    sample.set(chunk, offset);
+    offset += chunk.length;
+  });
+  return new TextDecoder().decode(sample);
+}
+
+function isChallengeResponse(response: Response, bodySample: string): boolean {
+  const { headers } = response;
+  const server = headers.get('server')?.toLowerCase() ?? '';
+  const mitigated = headers.get('cf-mitigated')?.toLowerCase() ?? '';
+  return mitigated === 'challenge'
+    || (response.status === 403 && server.includes('cloudflare'))
+    || /cf-chl-|just a moment|captcha|incapsula|akamai|access denied/i.test(bodySample);
+}
+
+async function classifyResponse(response: Response): Promise<LinkCheckResult> {
+  let state = classifyLinkStatus(response.status);
+  if ([403, 429, 503].includes(response.status)) {
+    const bodySample = await readResponseSample(response);
+    if (isChallengeResponse(response, bodySample)) {
+      state = 'blocked';
+    }
+  } else if (response.body) {
+    await Promise.allSettled([response.body.cancel()]);
+  }
+  return {
+    state,
+    status: response.status,
+    statusText: response.statusText,
+  };
+}
+
+function getRetryDelay(response: Response | undefined): number {
+  const retryAfter = response?.headers?.get('retry-after');
+  if (!retryAfter) {
+    return RETRY_DELAY_MS;
+  }
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) {
+    return Math.min(Math.max(seconds * 1000, RETRY_DELAY_MS), 5000);
+  }
+  const date = Date.parse(retryAfter);
+  return Number.isNaN(date) ? RETRY_DELAY_MS : Math.min(Math.max(date - Date.now(), RETRY_DELAY_MS), 5000);
+}
+
+function shouldRetry(result: LinkCheckResult): boolean {
+  return result.state === 'dead'
+    || result.state === 'transient'
+    || result.status === 429;
+}
+
+async function waitForHost(url: string, dependencies: LinkCheckerDependencies): Promise<void> {
+  const host = new URL(url).hostname;
+  const nextRequestAt = hostNextRequestAt.get(host) ?? 0;
+  const delay = nextRequestAt - dependencies.now();
+  if (delay > 0) {
+    await dependencies.sleep(delay);
+  }
+  hostNextRequestAt.set(host, dependencies.now() + HOST_INTERVAL_MS);
+}
+
+async function requestLink(
+  url: string,
+  pageTitle: string | undefined,
+  dependencies: LinkCheckerDependencies,
+): Promise<{ result: LinkCheckResult; response?: Response }> {
+  await waitForHost(url, dependencies);
+  let response: Response | undefined;
+  try {
+    const referrer = getReferrer(pageTitle);
+    response = await dependencies.fetchFn(url, {
+      headers: {
+        'User-Agent': getExternalLinkUserAgent(),
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'he-IL,he;q=0.9,en;q=0.7',
+        ...(referrer ? { Referer: referrer } : {}),
+      },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    return { result: await classifyResponse(response), response };
+  } catch (error) {
+    return {
+      result: {
+        state: 'transient',
+        error: error instanceof Error ? error.message : String(error),
+      },
+      response,
+    };
+  }
+}
+
+async function checkLink(
+  url: string,
+  pageTitle: string | undefined,
+  dependencies: LinkCheckerDependencies,
+): Promise<LinkCheckResult> {
+  const cached = resultCache.get(url);
+  if (cached && cached.expiresAt > dependencies.now()) {
+    return cached.result;
+  }
+  const initialCheck = await requestLink(url, pageTitle, dependencies);
+  const { response } = initialCheck;
+  let { result } = initialCheck;
+  if (shouldRetry(result)) {
+    await dependencies.sleep(getRetryDelay(response));
+    ({ result } = await requestLink(url, pageTitle, dependencies));
+  }
+  const ttl = result.state === 'transient' ? TRANSIENT_CACHE_TTL_MS : CACHE_TTL_MS;
+  resultCache.set(url, { result, expiresAt: dependencies.now() + ttl });
+  return result;
+}
+
+export async function checkLinksWithHttp(
+  links: WikiLink[],
+  pageTitle?: string,
+  dependencyOverrides: Partial<LinkCheckerDependencies> = {},
+): Promise<Map<string, LinkCheckResult>> {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  const uniqueUrls = [...new Set(links.map((link) => link.link))];
+  const results = new Map<string, LinkCheckResult>();
+  for (const url of uniqueUrls) {
+    results.set(url, await checkLink(url, pageTitle, dependencies));
+  }
+  return results;
+}
+
+export function clearLinkCheckCache(): void {
+  resultCache.clear();
+  hostNextRequestAt.clear();
+}

--- a/bot/tag-bot/actions/internetArchiveBot.ts
+++ b/bot/tag-bot/actions/internetArchiveBot.ts
@@ -1,0 +1,126 @@
+import { getExternalLinkUserAgent, LinkCheckState } from './externalLinkChecker';
+
+type IABotUrlRecord = {
+  url?: string;
+  normalizedurl?: string;
+  accesstime?: string;
+  live_state?: string;
+};
+
+type IABotResponse = {
+  urls?: Record<string, IABotUrlRecord>;
+};
+
+type IABotDependencies = {
+  fetchFn: typeof fetch;
+  now: () => number;
+};
+
+const IABOT_API_URL = 'https://iabot.wmcloud.org/api.php';
+const REQUEST_TIMEOUT_MS = 15 * 1000;
+const MAX_RESULT_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+const resultCache = new Map<string, { state: LinkCheckState; expiresAt: number }>();
+
+const defaultDependencies: IABotDependencies = {
+  fetchFn: fetch,
+  now: Date.now,
+};
+
+function normalizeUrl(url: string): string {
+  try {
+    return new URL(url).toString();
+  } catch {
+    return url;
+  }
+}
+
+function isFresh(record: IABotUrlRecord, now: number): boolean {
+  if (record.live_state === 'whitelisted' || record.live_state === 'blacklisted') {
+    return true;
+  }
+  if (!record.accesstime) {
+    return false;
+  }
+  const accessTime = Date.parse(`${record.accesstime}Z`);
+  return !Number.isNaN(accessTime) && now - accessTime <= MAX_RESULT_AGE_MS;
+}
+
+function mapState(record: IABotUrlRecord, now: number): LinkCheckState {
+  if (!isFresh(record, now)) {
+    return 'unknown';
+  }
+  switch (record.live_state) {
+  case 'alive':
+  case 'whitelisted':
+    return 'alive';
+  case 'dead':
+  case 'blacklisted':
+    return 'dead';
+  case 'dying':
+    return 'transient';
+  case 'paywall':
+    return 'blocked';
+  default:
+    return 'unknown';
+  }
+}
+
+export async function lookupIABotLinks(
+  urls: string[],
+  dependencyOverrides: Partial<IABotDependencies> = {},
+): Promise<Map<string, LinkCheckState>> {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  const uniqueUrls = [...new Set(urls)];
+  const results = new Map<string, LinkCheckState>();
+  const uncachedUrls = uniqueUrls.filter((url) => {
+    const cached = resultCache.get(normalizeUrl(url));
+    if (cached && cached.expiresAt > dependencies.now()) {
+      results.set(url, cached.state);
+      return false;
+    }
+    return true;
+  });
+  if (uncachedUrls.length === 0) {
+    return results;
+  }
+  const body = new URLSearchParams({
+    action: 'searchurldata',
+    wiki: 'hewiki',
+    urls: uncachedUrls.join('\n'),
+  });
+  const response = await dependencies.fetchFn(IABOT_API_URL, {
+    method: 'POST',
+    headers: {
+      'User-Agent': getExternalLinkUserAgent(),
+      Accept: 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    if (response.body) {
+      await Promise.allSettled([response.body.cancel()]);
+    }
+    throw new Error(`IABot returned ${response.status} ${response.statusText}`);
+  }
+  const data = await response.json() as IABotResponse;
+  const records = Object.values(data.urls ?? {});
+  uncachedUrls.forEach((url) => {
+    const normalized = normalizeUrl(url);
+    const record = records.find((candidate) => candidate.url === url
+      || candidate.normalizedurl === url
+      || normalizeUrl(candidate.url ?? '') === normalized
+      || normalizeUrl(candidate.normalizedurl ?? '') === normalized);
+    const state = record ? mapState(record, dependencies.now()) : 'unknown';
+    results.set(url, state);
+    resultCache.set(normalized, { state, expiresAt: dependencies.now() + CACHE_TTL_MS });
+  });
+  return results;
+}
+
+export function clearIABotCache(): void {
+  resultCache.clear();
+}

--- a/bot/tag-bot/playwrightCheck/index.ts
+++ b/bot/tag-bot/playwrightCheck/index.ts
@@ -1,8 +1,9 @@
 import {
-  Browser, BrowserContext, Page, chromium,
+  Browser, BrowserContext, Page, Response as PlaywrightResponse, chromium,
 } from 'playwright';
 import botLoggerDecorator from '../../decorators/botLoggerDecorator';
 import WikiApi, { IWikiApi } from '../../wiki/WikiApi';
+import { classifyLinkStatus, LinkCheckState } from '../actions/externalLinkChecker';
 
 export type PlaywrightLinkCheckRequestLink = {
   link: string;
@@ -11,6 +12,7 @@ export type PlaywrightLinkCheckRequestLink = {
 
 export type PlaywrightLinkCheckResult = PlaywrightLinkCheckRequestLink & {
   ok: boolean;
+  state: LinkCheckState;
   status: number;
   statusText: string;
   error?: string;
@@ -46,24 +48,56 @@ const launchOptions = {
   ],
 };
 
-const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36';
+const navigationOptions = {
+  waitUntil: 'domcontentloaded' as const,
+  timeout: 30 * 1000,
+};
+
+const challengeStatuses = [403, 429, 503];
+
+async function hasChallengePage(page: Page): Promise<boolean> {
+  const [title, content] = await Promise.allSettled([page.title(), page.content()]);
+  const titleText = title.status === 'fulfilled' ? title.value : '';
+  const contentText = content.status === 'fulfilled' ? content.value : '';
+  return /cf-chl-|just a moment|captcha|incapsula|akamai|access denied/i.test(`${titleText}\n${contentText}`);
+}
+
+async function retryChallengeResponse(
+  page: Page,
+  response: PlaywrightResponse,
+): Promise<PlaywrightResponse> {
+  if (!challengeStatuses.includes(response.status())) {
+    return response;
+  }
+  await page.waitForTimeout(5000);
+  try {
+    return await page.reload(navigationOptions) ?? response;
+  } catch {
+    return response;
+  }
+}
 
 async function checkLink(page: Page, link: PlaywrightLinkCheckRequestLink): Promise<PlaywrightLinkCheckResult> {
   try {
-    const response = await page.goto(link.link, {
-      waitUntil: 'domcontentloaded',
-      timeout: 30 * 1000,
-    });
+    const initialResponse = await page.goto(link.link, navigationOptions);
+    const response = initialResponse ? await retryChallengeResponse(page, initialResponse) : null;
+    const status = response?.status() ?? 0;
+    let state = response ? classifyLinkStatus(status) : 'unknown';
+    if (response && challengeStatuses.includes(status) && await hasChallengePage(page)) {
+      state = 'blocked';
+    }
     return {
       ...link,
-      ok: response?.ok() ?? false,
-      status: response?.status() ?? 0,
+      ok: state === 'alive',
+      state,
+      status,
       statusText: response?.statusText() ?? '',
     };
   } catch (error) {
     return {
       ...link,
       ok: false,
+      state: 'transient',
       status: 0,
       statusText: '',
       error: error instanceof Error ? error.message : String(error),
@@ -72,11 +106,21 @@ async function checkLink(page: Page, link: PlaywrightLinkCheckRequestLink): Prom
 }
 
 export async function runLinkChecks(links: PlaywrightLinkCheckRequestLink[]): Promise<PlaywrightLinkCheckResponse> {
+  if (links.length === 0) {
+    return { results: [] };
+  }
   let browser: Browser | null = null;
   let context: BrowserContext | null = null;
   try {
     browser = await chromium.launch(launchOptions);
-    context = await browser.newContext({ userAgent });
+    context = await browser.newContext({
+      locale: 'he-IL',
+      timezoneId: 'Asia/Jerusalem',
+      viewport: { width: 1280, height: 720 },
+      extraHTTPHeaders: {
+        'Accept-Language': 'he-IL,he;q=0.9,en;q=0.7',
+      },
+    });
     const results: PlaywrightLinkCheckResult[] = [];
 
     for (const link of links) {
@@ -98,10 +142,16 @@ export async function runLinkChecks(links: PlaywrightLinkCheckRequestLink[]): Pr
 export async function handleQueueMessage(api: IWikiApi, body: string) {
   const message = JSON.parse(body) as PlaywrightLinkCheckRequest;
   const results = await runLinkChecks(message.links ?? []);
-  const failed = results.results.filter((result) => !result.ok);
-  const content = failed.length === 0
-    ? 'כל הקישורים שנבדקו ברקע תקינים'
-    : `קישורים שנכשלו בבדיקה ברקע:\n${failed.map((link) => `* [${link.link} ${link.text}], ${link.error ?? `לא ניתן להגיע לקישור - ${link.status} - ${link.statusText}`}`).join('\n')}`;
+  const dead = results.results.filter((result) => result.state === 'dead');
+  const unresolved = results.results.filter((result) => !['alive', 'dead'].includes(result.state));
+  const sections: string[] = [];
+  if (dead.length > 0) {
+    sections.push(`קישורים שבורים בבדיקה ברקע:\n${dead.map((link) => `* [${link.link} ${link.text}], לא ניתן להגיע לקישור - ${link.status} - ${link.statusText}`).join('\n')}`);
+  }
+  if (unresolved.length > 0) {
+    sections.push(`קישורים שלא ניתן היה לאמת בבדיקה ברקע:\n${unresolved.map((link) => `* [${link.link} ${link.text}], ${link.error ?? `לא ניתן לאמת את הקישור - ${link.status} - ${link.statusText}`}`).join('\n')}`);
+  }
+  const content = sections.length === 0 ? 'כל הקישורים שנבדקו ברקע תקינים' : sections.join('\n');
 
   if (message.title && message.commentSummary && message.commentId) {
     await api.addComment(message.title, message.commentSummary, content, message.commentId);


### PR DESCRIPTION
## Summary

- classify link checks as alive, dead, blocked, transient, or unknown instead of treating every request failure as a broken link
- batch unresolved URLs through InternetArchiveBot and trust fresh or permanent domain results
- add per-host throttling, bounded retries, timeouts, honest bot identification, and result caching
- use Playwright only as a background fallback, retry likely challenge responses once, and report unresolved links separately from confirmed broken links
- add unit coverage for HTTP, IABot, page-check, and Playwright behavior

## Why

A 403, 429, challenge page, timeout, or temporary 5xx response usually says more about the checker being blocked than about the destination being dead. This keeps those outcomes from producing false broken-link reports while still confirming repeated 404/410 responses and IABot dead results.

## Validation

- `npm run type-check`
- `npm run lint:test`
- `npm run build`
- full CI-equivalent Jest run: 41 suites and 836 tests passed
- 100% statements, branches, functions, and lines coverage