### PR TITLE
interwikiLinks: run every ten minutes without redundant API load

### DIFF
--- a/bot/__tests__/interwikiLinks.test.ts
+++ b/bot/__tests__/interwikiLinks.test.ts
@@ -26,6 +26,8 @@ const {
   readRedirectTarget,
   replaceTemplateForeignTitle,
   formatLog,
+  parseRemainingPageTitles,
+  formatRemainingPageTitles,
   addTemplateWithoutWikidataItem,
   fixTitleBracketsAndDots,
   handlePageSafely,
@@ -46,6 +48,9 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
     api.getParsedContent.mockResolvedValue('<div>No errors</div>');
     api.articleContent.mockResolvedValue({ content: '', revid: 1 });
     api.create.mockResolvedValue({ revid: 1 });
+    api.categroyTitles.mockImplementation(async function* generator() {
+      yield [{ title: 'Page1' } as WikiPage];
+    });
     mockLanguageApi.getRedirecTarget.mockResolvedValue({});
     mockLanguageApi.info.mockResolvedValue([]);
     mockLanguageApi.search.mockImplementation(async function* generator() {
@@ -60,13 +65,15 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
       }];
       yield x;
     });
-    api.articleContent.mockRejectedValueOnce(new Error('does not exist'));
+    api.articleContent
+      .mockResolvedValueOnce({ content: '', revid: 2 })
+      .mockRejectedValueOnce(new Error('does not exist'));
     api.create.mockResolvedValueOnce(undefined);
 
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.create).toHaveBeenCalledWith(
-      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות`,
+      'ויקיפדיה:בוט/קישורי שפה',
       'תיקון קישורי שפה',
       '\n\n* [[Page1]]: <nowiki>{{|}}</nowiki> - [[::]] - דולג: לא נמצאו שגיאות',
     );
@@ -79,11 +86,13 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
       }];
       yield x;
     });
-    api.articleContent.mockResolvedValueOnce({ revid: 1, content: '' });
+    api.articleContent
+      .mockResolvedValueOnce({ revid: 2, content: '' })
+      .mockResolvedValueOnce({ revid: 1, content: '' });
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.edit).toHaveBeenCalledWith(
-      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות`,
+      'ויקיפדיה:בוט/קישורי שפה',
       'תיקון קישורי שפה',
       '\n\n* [[Page1]]: <nowiki>{{|}}</nowiki> - [[::]] - דולג: לא נמצאו שגיאות',
       1,
@@ -98,15 +107,80 @@ describe('foreignWikipediaMissingLinksParsedContent', () => {
       yield x;
     });
     api.getParsedContent.mockRejectedValueOnce(new Error('custom failure'));
-    api.articleContent.mockResolvedValueOnce({ revid: 1, content: '' });
+    api.articleContent
+      .mockResolvedValueOnce({ revid: 2, content: '' })
+      .mockResolvedValueOnce({ revid: 1, content: '' });
 
     await foreignWikipediaMissingLinksParsedContent(api);
 
     expect(api.edit).toHaveBeenCalledWith(
-      `user:${process.env.BOT_NAME}/קישורי שפה - הפניות`,
+      'ויקיפדיה:בוט/קישורי שפה',
       'תיקון קישורי שפה',
       expect.stringContaining('דולג: custom failure'),
       1,
+    );
+  });
+
+  it('stops before loading page content when the category has no new pages', async () => {
+    api.articleContent.mockResolvedValueOnce({
+      content: '* [[Page1]]',
+      revid: 2,
+    });
+
+    await foreignWikipediaMissingLinksParsedContent(api);
+
+    expect(api.categroyTitles).toHaveBeenCalledTimes(1);
+    expect(api.categroyPages).not.toHaveBeenCalled();
+    expect(api.edit).not.toHaveBeenCalled();
+    expect(api.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the remaining-pages subpage after the first full run', async () => {
+    api.articleContent
+      .mockRejectedValueOnce(new Error('No revid for ויקיפדיה:בוט/קישורי שפה/דפים שלא תוקנו'))
+      .mockResolvedValueOnce({ revid: 1, content: '' });
+    api.categroyPages.mockImplementation(async function* generator() {
+      yield [];
+    });
+
+    await foreignWikipediaMissingLinksParsedContent(api);
+
+    expect(api.create).toHaveBeenCalledWith(
+      'ויקיפדיה:בוט/קישורי שפה/דפים שלא תוקנו',
+      'תיקון קישורי שפה',
+      expect.stringContaining('* [[Page1]]'),
+    );
+  });
+
+  it('does not load page content when reading the tracking page fails', async () => {
+    api.articleContent.mockRejectedValueOnce(new Error('temporary failure'));
+
+    await expect(foreignWikipediaMissingLinksParsedContent(api)).rejects.toThrow('temporary failure');
+
+    expect(api.categroyPages).not.toHaveBeenCalled();
+  });
+});
+
+describe('remaining category pages', () => {
+  it('parses only list entries and normalizes category links', () => {
+    expect(parseRemainingPageTitles(`
+intro
+* [[Page1|display text]]
+* [[:קטגוריה:Page2]]
+not a list entry [[Ignored]]
+`)).toStrictEqual(['Page1', 'קטגוריה:Page2']);
+  });
+
+  it('formats a sorted page list without categorizing the tracking page', () => {
+    expect(formatRemainingPageTitles(['Page2', 'Page1', 'קטגוריה:Page3'])).toBe(
+      'הדפים הבאים עדיין נמצאים ב[[קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]:\n\n'
+      + '* [[:קטגוריה:Page3]]\n* [[Page1]]\n* [[Page2]]',
+    );
+  });
+
+  it('formats an empty page list', () => {
+    expect(formatRemainingPageTitles([])).toBe(
+      'הדפים הבאים עדיין נמצאים ב[[קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]: אין דפים.',
     );
   });
 });
@@ -1219,16 +1293,19 @@ describe('runSinglePage', () => {
     api.categroyPages.mockImplementation(async function* generator() {
       yield [];
     });
+    api.categroyTitles.mockImplementation(async function* generator() {
+      yield [{ title: 'TestPage' } as WikiPage];
+    });
     mockLanguageApi.getRedirecTarget.mockResolvedValueOnce({ redirect: { from: 'TestPage', to: 'NewGoogle' } });
     mockLanguageApi.info.mockResolvedValueOnce([{ missing: '' }]);
 
     await runSinglePage('TestPage', api);
     await foreignWikipediaMissingLinksParsedContent(api);
 
-    const logEditCall = api.edit.mock.calls.at(-1);
+    const logEditCall = api.edit.mock.calls.find(([title]) => title === 'ויקיפדיה:בוט/קישורי שפה');
 
     expect(logEditCall).toBeDefined();
-    expect(logEditCall?.[0]).toBe(`user:${process.env.BOT_NAME}/קישורי שפה - הפניות`);
+    expect(logEditCall?.[0]).toBe('ויקיפדיה:בוט/קישורי שפה');
     expect(logEditCall?.[1]).toBe('תיקון קישורי שפה');
     expect(logEditCall?.[2]).toStrictEqual(expect.stringContaining('* [[TestPage]]: <nowiki>{{אנג|Google}}</nowiki> - [[:en:Google]] ← [[:en:NewGoogle]] - דולג: התבנית המתאימה לא נמצאה'));
     expect(logEditCall?.[3]).toBe(1);

--- a/bot/interwikiLinks/index.ts
+++ b/bot/interwikiLinks/index.ts
@@ -11,10 +11,12 @@ import {
   templateFromTemplateData,
 } from '../wiki/newTemplateParser';
 import { getRedirectTargetFromContent } from '../wiki/redirectParser';
+import { getInnerLinks } from '../wiki/wikiLinkParser';
 import { WikiPage } from '../types';
 
 const CATEGORY_TITLE = 'קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה';
-const LOG_PAGE_TITLE = `user:${process.env.BOT_NAME}/קישורי שפה - הפניות`;
+const LOG_PAGE_TITLE = 'ויקיפדיה:בוט/קישורי שפה';
+const REMAINING_PAGES_TITLE = `${LOG_PAGE_TITLE}/דפים שלא תוקנו`;
 const EDIT_SUMMARY = 'תיקון קישורי שפה';
 const VALIDATOR_ERROR_SELECTOR = '.paramvalidator-error';
 const VALIDATOR_ERROR_REGEX = /שימוש בתבנית\s+(.+?)\s+עבור\s+"(.+?)"\s+בשפה\s+([a-z-]+)\s+אך ערך זה לא קיים בשפה זו/i;
@@ -425,6 +427,58 @@ export function formatLog(log: TemplateCheckLog): string {
   return `* [[${normalizeTitleForLogs(log.pageTitle)}]]: <nowiki>{{${log.templateName}|${log.foreignTitle}}}</nowiki> - [[:${log.languageCode}:${log.foreignTitle}]]${target} - ${result}`;
 }
 
+export function parseRemainingPageTitles(content: string): string[] {
+  return content
+    .split('\n')
+    .filter((line) => line.startsWith('* '))
+    .flatMap((line) => getInnerLinks(line).map(({ link }) => link));
+}
+
+export function formatRemainingPageTitles(titles: string[]): string {
+  const pageList = [...titles]
+    .sort((a, b) => a.localeCompare(b, 'he'))
+    .map((title) => `* [[${normalizeTitleForLogs(title)}]]`)
+    .join('\n');
+
+  return `הדפים הבאים עדיין נמצאים ב[[${CATEGORY_TITLE}]]:${pageList ? `\n\n${pageList}` : ' אין דפים.'}`;
+}
+
+async function getCategoryTitles(api: IWikiApi): Promise<string[]> {
+  const titles: string[] = [];
+
+  for await (const pages of api.categroyTitles(normalizeCategoryName(CATEGORY_TITLE))) {
+    titles.push(...pages.map((page) => page.title));
+  }
+
+  return titles;
+}
+
+async function readPreviousRemainingPages(api: IWikiApi): Promise<{
+  titles: string[];
+  revid?: number;
+}> {
+  try {
+    const { content, revid } = await api.articleContent(REMAINING_PAGES_TITLE);
+    return { titles: parseRemainingPageTitles(content), revid };
+  } catch (error) {
+    if (String(error) !== `Error: No revid for ${REMAINING_PAGES_TITLE}`) {
+      throw error;
+    }
+    return { titles: [] };
+  }
+}
+
+async function writeRemainingPages(api: IWikiApi, titles: string[], revid?: number): Promise<void> {
+  const content = formatRemainingPageTitles(titles);
+
+  if (revid == null) {
+    await api.create(REMAINING_PAGES_TITLE, EDIT_SUMMARY, content);
+    return;
+  }
+
+  await api.edit(REMAINING_PAGES_TITLE, EDIT_SUMMARY, content, revid);
+}
+
 async function writeLogs(api: IWikiApi): Promise<void> {
   const successLogs = logs.filter((log) => log.success);
   const logContent = successLogs.map(formatLog).join('\n');
@@ -494,6 +548,16 @@ export async function runSinglePage(title: string, api: IWikiApi): Promise<void>
 }
 
 export default async function interwikiLinks(api: IWikiApi): Promise<void> {
+  const categoryTitles = await getCategoryTitles(api);
+  const previousRemainingPages = await readPreviousRemainingPages(api);
+  const previousTitles = new Set(previousRemainingPages.titles);
+
+  const hasNewPage = categoryTitles.some((title) => !previousTitles.has(title));
+  if (previousRemainingPages.revid != null && !hasNewPage) {
+    console.log('No new pages in the category');
+    return;
+  }
+
   await asyncGeneratorMapWithSequence(
     5,
     api.categroyPages(normalizeCategoryName(CATEGORY_TITLE)),
@@ -501,4 +565,5 @@ export default async function interwikiLinks(api: IWikiApi): Promise<void> {
   );
 
   await writeLogs(api);
+  await writeRemainingPages(api, await getCategoryTitles(api), previousRemainingPages.revid);
 }

--- a/build/t01.cf.yaml
+++ b/build/t01.cf.yaml
@@ -493,5 +493,5 @@ Resources:
         Schedule:
           Type: Schedule
           Properties:
-            Schedule: cron(0 5,17 ? * * *)
+            Schedule: rate(10 minutes)
             Name: interwiki-links-scheduler


### PR DESCRIPTION
## What changed

- move the interwiki-links run log to `ויקיפדיה:בוט/קישורי שפה`
- maintain `ויקיפדיה:בוט/קישורי שפה/דפים שלא תוקנו` with the pages that remain in the category
- fetch category titles only at startup and stop before loading page content when no new title has appeared since the previous full run
- perform the normal full run when a new category member is detected, then refresh the remaining-pages list
- propagate tracking-page API failures instead of treating them as a missing page and accidentally triggering an expensive full run
- change the CloudFormation schedule to `rate(10 minutes)`

## Why

The bot should react quickly to new category members without repeatedly fetching and parsing every page when the category is unchanged. The persisted remaining-pages list provides the comparison baseline and a visible status page.

## Validation

- `npm run type-check`
- `npm run lint:test`
- `npm test -- --runInBand` — 851 tests passed, 100% coverage
- `npm run smoke-test`
- local YAML parse and assertion of `rate(10 minutes)`

The AWS-backed CloudFormation validation could not run in this workspace because access to the instance-metadata endpoint is blocked; GitHub CI will run the repository's full validation.