### PR TITLE
interwikiLinks: avoid categorizing the tracking page

### DIFF
--- a/bot/__tests__/interwikiLinks.test.ts
+++ b/bot/__tests__/interwikiLinks.test.ts
@@ -173,14 +173,14 @@ not a list entry [[Ignored]]
 
   it('formats a sorted page list without categorizing the tracking page', () => {
     expect(formatRemainingPageTitles(['Page2', 'Page1', 'קטגוריה:Page3'])).toBe(
-      'הדפים הבאים עדיין נמצאים ב[[קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]:\n\n'
+      'הדפים הבאים עדיין נמצאים ב[[:קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]:\n\n'
       + '* [[:קטגוריה:Page3]]\n* [[Page1]]\n* [[Page2]]',
     );
   });
 
   it('formats an empty page list', () => {
     expect(formatRemainingPageTitles([])).toBe(
-      'הדפים הבאים עדיין נמצאים ב[[קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]: אין דפים.',
+      'הדפים הבאים עדיין נמצאים ב[[:קטגוריה:קישור לערך לא קיים בוויקיפדיה זרה]]: אין דפים.',
     );
   });
 });

--- a/bot/interwikiLinks/index.ts
+++ b/bot/interwikiLinks/index.ts
@@ -440,7 +440,7 @@ export function formatRemainingPageTitles(titles: string[]): string {
     .map((title) => `* [[${normalizeTitleForLogs(title)}]]`)
     .join('\n');
 
-  return `הדפים הבאים עדיין נמצאים ב[[${CATEGORY_TITLE}]]:${pageList ? `\n\n${pageList}` : ' אין דפים.'}`;
+  return `הדפים הבאים עדיין נמצאים ב[[:${CATEGORY_TITLE}]]:${pageList ? `\n\n${pageList}` : ' אין דפים.'}`;
 }
 
 async function getCategoryTitles(api: IWikiApi): Promise<string[]> {


### PR DESCRIPTION
## What changed

- render the category reference in the remaining-pages header as `[[:קטגוריה:...]]`
- update both non-empty and empty-list expectations

## Why

`[[קטגוריה:...]]` categorizes the tracking page itself. The leading colon keeps the category name as a normal link without adding the page to that category.

## Validation

- `npm run type-check`
- `npm run lint:test`
- `npm test -- --runInBand` — 851 tests passed, 100% coverage