### PR TITLE
Include archive target in targeted archive edit summaries

### DIFF
--- a/bot/__tests__/ClosedDiscussionsArchiveBotModel.test.ts
+++ b/bot/__tests__/ClosedDiscussionsArchiveBotModel.test.ts
@@ -1302,7 +1302,12 @@ Content
 
       expect(wikiApi.edit).toHaveBeenCalledWith('TestPage/ארכיון 1', expect.any(String), expect.not.stringContaining('{{הועבר'), expect.any(Number));
       // Source page edit should fully remove the paragraph (no stub for non-targeted)
-      expect(wikiApi.edit).toHaveBeenCalledWith('TestPage', expect.any(String), expect.not.stringContaining('~~~~'), expect.any(Number));
+      expect(wikiApi.edit).toHaveBeenCalledWith(
+        'TestPage',
+        expect.not.stringContaining('אורכב ל-'),
+        expect.not.stringContaining('~~~~'),
+        expect.any(Number),
+      );
 
       wikiApi.create.mockClear();
       wikiApi.edit.mockClear();
@@ -1310,7 +1315,17 @@ Content
       // 2. isTargeted = true (via תבנית ארכיון עם יעד algorithm for paragraph with ארכוב)
       await model.archive('TestPage', [paragraphWithTarget], 'תבנית ארכיון עם יעד', 'TestPage/Navigate');
 
-      expect(wikiApi.create).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.stringContaining('{{הועבר'));
+      expect(wikiApi.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('אורכב ל-[[TargetPage]]'),
+        expect.stringContaining('{{הועבר'),
+      );
+      expect(wikiApi.edit).toHaveBeenCalledWith(
+        'TestPage',
+        expect.stringContaining('אורכב ל-[[TargetPage]]'),
+        expect.any(String),
+        expect.any(Number),
+      );
       // Archive page edit should include stub with הועבר|ל and ~~~~
       expect(wikiApi.edit).toHaveBeenCalledWith(
         'TestPage/ארכיון 1',

--- a/bot/maintenance/closedDiscussionsArchiveBot/ClosedDiscussionsArchiveBotModel.ts
+++ b/bot/maintenance/closedDiscussionsArchiveBot/ClosedDiscussionsArchiveBotModel.ts
@@ -111,10 +111,12 @@ function createArchiveSummary(
   paragraphName: string,
   status: string,
   handler?: string,
+  archiveTarget?: string,
   archive = true,
 ): string {
   const handlerPart = handler ? ` מטפל: [[user:${handler}|${handler}]].` : '';
-  return `${SUMMARY_PREFIX}: ${archive ? 'ארכוב' : 'מחיקת'} הדיון "${paragraphName}", ${status}.${handlerPart}`;
+  const archiveTargetPart = archiveTarget ? ` אורכב ל-[[${archiveTarget}]]` : '';
+  return `${SUMMARY_PREFIX}: ${archive ? 'ארכוב' : 'מחיקת'} הדיון "${paragraphName}", ${status}.${handlerPart}${archiveTargetPart}`;
 }
 
 function getQuarterFromDate(date: Date): { firstMonth: string; lastMonth: string; year: number } {
@@ -333,6 +335,7 @@ export default function ClosedDiscussionsArchiveBotModel(
       paragraphName,
       templateData.status,
       templateData.handler,
+      isTargeted ? archiveTitle : undefined,
     );
 
     const existingArchiveContent = await getContentOrNull(wikiApi, archiveTitle);
@@ -494,6 +497,7 @@ export default function ClosedDiscussionsArchiveBotModel(
           name,
           templateData.status,
           templateData.handler,
+          undefined,
           false,
         );
         const newContent = removeParagraphsFromContent(pageContent, [paragraph]);


### PR DESCRIPTION
## What changed

- Append `אורכב ל-[[${archiveTarget}]]` to edit summaries when a closed discussion is archived to an explicit target.
- Keep summaries for regular, non-targeted archives unchanged.
- Add focused assertions for both targeted and non-targeted flows.

## Why

Targeted archive edits previously used the same summary as regular archive edits, so the destination page was not visible from the page history.

## Impact

Page histories now identify the explicit archive destination with a clickable internal link.

## Validation

- TypeScript type-check passed.
- 850 Jest tests passed with 100% statement, branch, function, and line coverage (`TZ=Asia/Jerusalem`).
- ESLint passed.
- Production dependency smoke test passed.
- CloudFormation validation could not run in the sandbox because its initialization attempted restricted cloud instance-metadata access; no CloudFormation files were changed.