### PR TITLE
Update Playwright Docker image to 1.62

### DIFF
--- a/build/wiki-bot-playwright/Dockerfile
+++ b/build/wiki-bot-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.61.0-jammy AS playwright-browsers
+FROM mcr.microsoft.com/playwright:v1.62.0-jammy AS playwright-browsers
 
 FROM node:24
 


### PR DESCRIPTION
## What changed

Updated the Playwright browser Docker image from `v1.61.0-jammy` to `v1.62.0-jammy`.

## Impact

The `wiki-bot-playwright` build will use Playwright browsers version 1.62.

## Validation

Verified that the branch is one commit ahead of `master` and changes only `build/wiki-bot-playwright/Dockerfile` (one line replaced).